### PR TITLE
Change Identity from UInt8Array to Identity to match other SDKs

### DIFF
--- a/src/identity.ts
+++ b/src/identity.ts
@@ -1,0 +1,40 @@
+export class Identity {
+  private data: Uint8Array;
+
+  constructor(data: Uint8Array) {
+    this.data = data;
+  }
+
+  // Method to compare two identities
+  isEqual(other: Identity): boolean {
+    if (this.data.length !== other.data.length) {
+      return false;
+    }
+    for (let i = 0; i < this.data.length; i++) {
+      if (this.data[i] !== other.data[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // Method to convert the Uint8Array to a hex string
+  toHexString(): string {
+    return Array.prototype.map
+      .call(this.data, (x) => ("00" + x.toString(16)).slice(-2))
+      .join("");
+  }
+
+  toUint8Array(): Uint8Array {
+    return this.data;
+  }
+
+  // Static method to create an Identity from a hex string
+  static fromString(str: string): Identity {
+    let matches = str.match(/.{1,2}/g) || [];
+    let data = Uint8Array.from(
+      matches.map((byte: string) => parseInt(byte, 16))
+    );
+    return new Identity(data);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./spacetimedb";
+export * from "./identity";

--- a/tests/spacetimedb_client.test.ts
+++ b/tests/spacetimedb_client.test.ts
@@ -1,4 +1,5 @@
 import { SpacetimeDBClient, ReducerEvent } from "../src/spacetimedb";
+import { Identity } from "../src/identity";
 import WebsocketTestAdapter from "../src/websocket_test_adapter";
 import Player from "./types/player";
 import Point from "./types/point";
@@ -112,15 +113,12 @@ describe("SpacetimeDBClient", () => {
     );
 
     let reducerCallbackLog: {
-      status: string;
-      identity: Uint8Array;
+      reducerEvent: ReducerEvent;
       reducerArgs: any[];
     }[] = [];
-    CreatePlayerReducer.on(
-      (status: string, identity: Uint8Array, reducerArgs: any[]) => {
-        reducerCallbackLog.push({ status, identity, reducerArgs });
-      }
-    );
+    CreatePlayerReducer.on((reducerEvent: ReducerEvent, reducerArgs: any[]) => {
+      reducerCallbackLog.push({ reducerEvent, reducerArgs });
+    });
 
     const subscriptionMessage = {
       SubscriptionUpdate: {
@@ -183,7 +181,7 @@ describe("SpacetimeDBClient", () => {
     expect(inserts[1].reducerEvent?.status).toBe("committed");
     expect(inserts[1].reducerEvent?.message).toBe("a message");
     expect(inserts[1].reducerEvent?.callerIdentity).toEqual(
-      Uint8Array.from([0, 255, 1])
+      Identity.fromString("00FF01")
     );
     expect(inserts[1].reducerEvent?.args).toEqual([
       "A Player",
@@ -191,8 +189,9 @@ describe("SpacetimeDBClient", () => {
     ]);
 
     expect(reducerCallbackLog).toHaveLength(1);
-    expect(reducerCallbackLog[0]["identity"]).toEqual(
-      Uint8Array.from([0, 255, 1])
+
+    expect(reducerCallbackLog[0]["reducerEvent"]["callerIdentity"]).toEqual(
+      Identity.fromString("00FF01")
     );
   });
 

--- a/tests/types/create_player_reducer.ts
+++ b/tests/types/create_player_reducer.ts
@@ -11,6 +11,8 @@ import {
   IDatabaseTable,
   AlgebraicValue,
   ReducerArgsAdapter,
+  ReducerEvent,
+  Identity,
 } from "../../src/index";
 // @ts-ignore
 import { Point } from "./point";
@@ -32,7 +34,7 @@ export class CreatePlayerReducer {
   }
 
   public static on(
-    callback: (status: string, identity: Uint8Array, reducerArgs: any[]) => void
+    callback: (reducerEvent: ReducerEvent, reducerArgs: any[]) => void
   ) {
     if (__SPACETIMEDB__.spacetimeDBClient) {
       __SPACETIMEDB__.spacetimeDBClient.on("reducer:CreatePlayer", callback);


### PR DESCRIPTION
## Description of Changes
*Describe what has been changed, any new features or bug fixes*

UInt8Array -> Identity
Reducer callbacks now get a ReducerEvent instead of just caller and status

## API

 - [X ] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*

Projects using this SDK will need to:
- update their references to identities from UInt8Arrays to Identity
- update any reducer callbacks to take a ReducerEvent as the first argument

## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*

https://github.com/clockworklabs/SpacetimeDB/pull/94
