### PR TITLE
Fix BSATN serialization for c# module support

### DIFF
--- a/src/binary_writer.ts
+++ b/src/binary_writer.ts
@@ -20,7 +20,7 @@ export default class BinaryWriter {
   }
 
   getBuffer(): Uint8Array {
-    return this.buffer.slice(0, this.offset + 1);
+    return this.buffer.slice(0, this.offset);
   }
 
   writeUInt8Array(value: Uint8Array): void {
@@ -127,7 +127,7 @@ export default class BinaryWriter {
     const encoder = new TextEncoder();
     const encodedString = encoder.encode(value);
     this.writeU32(encodedString.length);
-    this.expandBuffer(4 + encodedString.length);
+    this.expandBuffer(encodedString.length);
     this.buffer.set(encodedString, this.offset);
     this.offset += encodedString.length;
   }


### PR DESCRIPTION
## Description of Changes
Typescript SDK was adding an extra 0 to the end of the buffer, this causes a bug in C# module implementation which actually validates the length

## API

 - [ ] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*


## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*
