### PR TITLE
Fix auth in the browser

### DIFF
--- a/src/spacetimedb.ts
+++ b/src/spacetimedb.ts
@@ -706,7 +706,11 @@ export class SpacetimeDBClient {
         }
       } else if (message instanceof IdentityTokenMessage) {
         this.identity = message.identity;
-        this.token = message.token;
+        if (this.runtime.auth_token) {
+          this.token = this.runtime.auth_token;
+        } else {
+          this.token = message.token;
+        }
         this.emitter.emit("connected", this.token, this.identity);
       }
     });


### PR DESCRIPTION
## Description of Changes
At the moment when we authenticate with the short-lived token we also get the short lived token back. In order to not give it back to the application let's just ignore the identity message token if we already got one

## API

 - [ ] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*


## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*
