### PR TITLE
Remove `protobufjs` from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "ts-node": "^10.9.1",
     "typescript": "^4.9.3",
     "ts-proto": "^1.150.1",
-    "protobufjs": "^7.2.4",
     "prettier-eslint": "^15.0.1"
   },
   "dependencies": {


### PR DESCRIPTION
## Description of Changes
`protobufjs` was defined twice in the package.json inside dependencies and devDependencies which causes bun (javascript runtime and bundler) to fail to install the dependencies.

```bash
bun install v0.8.1 (16b4bf34)


error: Duplicate dependency: "protobufjs" specified in package.json

    "protobufjs": "^7.2.4",
    ^
/home/jk/pr/spacetimedb-typescript-sdk/package.json:38:5 960

note: "protobufjs" originally specified here

    "protobufjs": "^7.2.4",
```

Since it's used during runtime (in client_api.ts) it should be in the dependencies.

## API

 - [ ] This is an API breaking change to the SDK

## Requires SpacetimeDB PRs
N/A
