### PR TITLE
Flatten SATS + convenience APIs

### DIFF
--- a/examples/quickstart/client/src/module_bindings/message.ts
+++ b/examples/quickstart/client/src/module_bindings/message.ts
@@ -6,7 +6,6 @@ import {
   __SPACETIMEDB__,
   AlgebraicType,
   ProductType,
-  BuiltinType,
   ProductTypeElement,
   SumType,
   SumTypeVariant,
@@ -41,19 +40,17 @@ export class Message extends IDatabaseTable {
         AlgebraicType.createProductType([
           new ProductTypeElement(
             "__identity_bytes",
-            AlgebraicType.createArrayType(
-              AlgebraicType.createPrimitiveType(BuiltinType.Type.U8)
-            )
+            AlgebraicType.createBytesType()
           ),
         ])
       ),
       new ProductTypeElement(
         "sent",
-        AlgebraicType.createPrimitiveType(BuiltinType.Type.U64)
+        AlgebraicType.createU64Type()
       ),
       new ProductTypeElement(
         "text",
-        AlgebraicType.createPrimitiveType(BuiltinType.Type.String)
+        AlgebraicType.createStringType()
       ),
     ]);
   }

--- a/examples/quickstart/client/src/module_bindings/send_message_reducer.ts
+++ b/examples/quickstart/client/src/module_bindings/send_message_reducer.ts
@@ -6,7 +6,6 @@ import {
   __SPACETIMEDB__,
   AlgebraicType,
   ProductType,
-  BuiltinType,
   ProductTypeElement,
   IDatabaseTable,
   AlgebraicValue,
@@ -22,16 +21,14 @@ export class SendMessageReducer {
   public static call(_text: string) {
     if (__SPACETIMEDB__.spacetimeDBClient) {
       const serializer = __SPACETIMEDB__.spacetimeDBClient.getSerializer();
-      let _textType = AlgebraicType.createPrimitiveType(
-        BuiltinType.Type.String
-      );
+      let _textType = AlgebraicType.createStringType();
       serializer.write(_textType, _text);
       __SPACETIMEDB__.spacetimeDBClient.call("send_message", serializer);
     }
   }
 
   public static deserializeArgs(adapter: ReducerArgsAdapter): any[] {
-    let textType = AlgebraicType.createPrimitiveType(BuiltinType.Type.String);
+    let textType = AlgebraicType.createStringType();
     let textValue = AlgebraicValue.deserialize(textType, adapter.next());
     let text = textValue.asString();
     return [text];

--- a/examples/quickstart/client/src/module_bindings/set_name_reducer.ts
+++ b/examples/quickstart/client/src/module_bindings/set_name_reducer.ts
@@ -6,7 +6,6 @@ import {
   __SPACETIMEDB__,
   AlgebraicType,
   ProductType,
-  BuiltinType,
   ProductTypeElement,
   IDatabaseTable,
   AlgebraicValue,
@@ -22,16 +21,14 @@ export class SetNameReducer {
   public static call(_name: string) {
     if (__SPACETIMEDB__.spacetimeDBClient) {
       const serializer = __SPACETIMEDB__.spacetimeDBClient.getSerializer();
-      let _nameType = AlgebraicType.createPrimitiveType(
-        BuiltinType.Type.String
-      );
+      let _nameType = AlgebraicType.createStringType();
       serializer.write(_nameType, _name);
       __SPACETIMEDB__.spacetimeDBClient.call("set_name", serializer);
     }
   }
 
   public static deserializeArgs(adapter: ReducerArgsAdapter): any[] {
-    let nameType = AlgebraicType.createPrimitiveType(BuiltinType.Type.String);
+    let nameType = AlgebraicType.createStringType();
     let nameValue = AlgebraicValue.deserialize(nameType, adapter.next());
     let name = nameValue.asString();
     return [name];

--- a/examples/quickstart/client/src/module_bindings/user.ts
+++ b/examples/quickstart/client/src/module_bindings/user.ts
@@ -6,7 +6,6 @@ import {
   __SPACETIMEDB__,
   AlgebraicType,
   ProductType,
-  BuiltinType,
   ProductTypeElement,
   SumType,
   SumTypeVariant,
@@ -47,9 +46,7 @@ export class User extends IDatabaseTable {
         AlgebraicType.createProductType([
           new ProductTypeElement(
             "__identity_bytes",
-            AlgebraicType.createArrayType(
-              AlgebraicType.createPrimitiveType(BuiltinType.Type.U8)
-            )
+            AlgebraicType.createBytesType()
           ),
         ])
       ),
@@ -58,14 +55,14 @@ export class User extends IDatabaseTable {
         AlgebraicType.createSumType([
           new SumTypeVariant(
             "some",
-            AlgebraicType.createPrimitiveType(BuiltinType.Type.String)
+            AlgebraicType.createStringType()
           ),
           new SumTypeVariant("none", AlgebraicType.createProductType([])),
         ])
       ),
       new ProductTypeElement(
         "online",
-        AlgebraicType.createPrimitiveType(BuiltinType.Type.Bool)
+        AlgebraicType.createBoolType()
       ),
     ]);
   }

--- a/src/algebraic_type.ts
+++ b/src/algebraic_type.ts
@@ -1,6 +1,6 @@
 /**
  * A variant of a sum type.
- * 
+ *
  * NOTE: Each element has an implicit element tag based on its order.
  * Uniquely identifies an element similarly to protobuf tags.
  */
@@ -15,29 +15,29 @@ export class SumTypeVariant {
 }
 
 /**
-* Unlike most languages, sums in SATS are *[structural]* and not nominal.
-* When checking whether two nominal types are the same,
-* their names and/or declaration sites (e.g., module / namespace) are considered.
-* Meanwhile, a structural type system would only check the structure of the type itself,
-* e.g., the names of its variants and their inner data types in the case of a sum.
-*
-* This is also known as a discriminated union (implementation) or disjoint union.
-* Another name is [coproduct (category theory)](https://ncatlab.org/nlab/show/coproduct).
-*
-* These structures are known as sum types because the number of possible values a sum
-* ```ignore
-* { N_0(T_0), N_1(T_1), ..., N_n(T_n) }
-* ```
-* is:
-* ```ignore
-* Σ (i ∈ 0..n). values(T_i)
-* ```
-* so for example, `values({ A(U64), B(Bool) }) = values(U64) + values(Bool)`.
-*
-* See also: https://ncatlab.org/nlab/show/sum+type.
-*
-* [structural]: https://en.wikipedia.org/wiki/Structural_type_system
-*/
+ * Unlike most languages, sums in SATS are *[structural]* and not nominal.
+ * When checking whether two nominal types are the same,
+ * their names and/or declaration sites (e.g., module / namespace) are considered.
+ * Meanwhile, a structural type system would only check the structure of the type itself,
+ * e.g., the names of its variants and their inner data types in the case of a sum.
+ *
+ * This is also known as a discriminated union (implementation) or disjoint union.
+ * Another name is [coproduct (category theory)](https://ncatlab.org/nlab/show/coproduct).
+ *
+ * These structures are known as sum types because the number of possible values a sum
+ * ```ignore
+ * { N_0(T_0), N_1(T_1), ..., N_n(T_n) }
+ * ```
+ * is:
+ * ```ignore
+ * Σ (i ∈ 0..n). values(T_i)
+ * ```
+ * so for example, `values({ A(U64), B(Bool) }) = values(U64) + values(Bool)`.
+ *
+ * See also: https://ncatlab.org/nlab/show/sum+type.
+ *
+ * [structural]: https://en.wikipedia.org/wiki/Structural_type_system
+ */
 export class SumType {
   public variants: SumTypeVariant[];
 
@@ -46,14 +46,14 @@ export class SumType {
   }
 }
 
-/** 
-* A factor / element of a product type.
-*
-* An element consist of an optional name and a type.
-*
-* NOTE: Each element has an implicit element tag based on its order.
-* Uniquely identifies an element similarly to protobuf tags.
-*/
+/**
+ * A factor / element of a product type.
+ *
+ * An element consist of an optional name and a type.
+ *
+ * NOTE: Each element has an implicit element tag based on its order.
+ * Uniquely identifies an element similarly to protobuf tags.
+ */
 export class ProductTypeElement {
   public name: string;
   public algebraicType: AlgebraicType;
@@ -65,30 +65,30 @@ export class ProductTypeElement {
 }
 
 /**
-* A structural product type  of the factors given by `elements`.
-*
-* This is also known as `struct` and `tuple` in many languages,
-* but note that unlike most languages, products in SATs are *[structural]* and not nominal.
-* When checking whether two nominal types are the same,
-* their names and/or declaration sites (e.g., module / namespace) are considered.
-* Meanwhile, a structural type system would only check the structure of the type itself,
-* e.g., the names of its fields and their types in the case of a record.
-* The name "product" comes from category theory.
-*
-* See also: https://ncatlab.org/nlab/show/product+type.
-*
-* These structures are known as product types because the number of possible values in product
-* ```ignore
-* { N_0: T_0, N_1: T_1, ..., N_n: T_n }
-* ```
-* is:
-* ```ignore
-* Π (i ∈ 0..n). values(T_i)
-* ```
-* so for example, `values({ A: U64, B: Bool }) = values(U64) * values(Bool)`.
-*
-* [structural]: https://en.wikipedia.org/wiki/Structural_type_system
-*/
+ * A structural product type  of the factors given by `elements`.
+ *
+ * This is also known as `struct` and `tuple` in many languages,
+ * but note that unlike most languages, products in SATs are *[structural]* and not nominal.
+ * When checking whether two nominal types are the same,
+ * their names and/or declaration sites (e.g., module / namespace) are considered.
+ * Meanwhile, a structural type system would only check the structure of the type itself,
+ * e.g., the names of its fields and their types in the case of a record.
+ * The name "product" comes from category theory.
+ *
+ * See also: https://ncatlab.org/nlab/show/product+type.
+ *
+ * These structures are known as product types because the number of possible values in product
+ * ```ignore
+ * { N_0: T_0, N_1: T_1, ..., N_n: T_n }
+ * ```
+ * is:
+ * ```ignore
+ * Π (i ∈ 0..n). values(T_i)
+ * ```
+ * so for example, `values({ A: U64, B: Bool }) = values(U64) * values(Bool)`.
+ *
+ * [structural]: https://en.wikipedia.org/wiki/Structural_type_system
+ */
 export class ProductType {
   public elements: ProductTypeElement[];
 
@@ -112,35 +112,184 @@ export class MapType {
   }
 }
 
-export class BuiltinType {
-  public type: BuiltinType.Type;
-  public arrayType: AlgebraicType | undefined;
-  public mapType: MapType | undefined;
+type ArrayBaseType = AlgebraicType;
+type TypeRef = null;
+type None = null;
 
-  constructor(
-    type: BuiltinType.Type,
-    arrayOrMapType: AlgebraicType | MapType | undefined
-  ) {
-    this.type = type;
-    if (arrayOrMapType !== undefined) {
-      if (arrayOrMapType.constructor === MapType) {
-        this.mapType = arrayOrMapType;
-      } else if (arrayOrMapType.constructor === AlgebraicType) {
-        this.arrayType = arrayOrMapType;
-      }
+type AnyType = ProductType | SumType | ArrayBaseType | MapType | TypeRef | None;
+
+/**
+ * The SpacetimeDB Algebraic Type System (SATS) is a structural type system in
+ * which a nominal type system can be constructed.
+ *
+ * The type system unifies the concepts sum types, product types, and built-in
+ * primitive types into a single type system.
+ */
+export class AlgebraicType {
+  type!: Type;
+  type_?: AnyType;
+
+  private setter(type: Type, payload: AnyType | undefined) {
+    this.type_ = payload;
+    this.type = payload === undefined ? Type.None : type;
+  }
+
+  public get product(): ProductType {
+    if (this.type !== Type.Product) {
+      throw "product type was requested, but the type is not ProductType";
     }
+    return this.type_ as ProductType;
+  }
+  public set product(value: ProductType | undefined) {
+    this.setter(Type.Product, value);
+  }
+
+  public get sum(): SumType {
+    if (this.type !== Type.Sum) {
+      throw "sum type was requested, but the type is not SumType";
+    }
+    return this.type_ as SumType;
+  }
+  public set sum(value: SumType | undefined) {
+    this.setter(Type.Sum, value);
+  }
+
+  public get array(): AlgebraicType {
+    if (this.type !== Type.Array) {
+      throw "array type was requested, but the type is not Array";
+    }
+    return this.type_ as AlgebraicType;
+  }
+  public set array(value: AlgebraicType | undefined) {
+    this.setter(Type.Array, value);
+  }
+
+  public get map(): MapType {
+    if (this.type !== Type.Map) {
+      throw "map type was requested, but the type is not MapType";
+    }
+    return this.type_ as MapType;
+  }
+  public set map(value: MapType | undefined) {
+    this.setter(Type.Map, value);
+  }
+
+  private static createType(
+    type: Type,
+    payload: AnyType | undefined
+  ): AlgebraicType {
+    let at = new AlgebraicType();
+    at.setter(type, payload);
+    return at;
+  }
+
+  public static createProductType(
+    elements: ProductTypeElement[]
+  ): AlgebraicType {
+    let type = new AlgebraicType();
+    type.product = new ProductType(elements);
+    return type;
+  }
+
+  public static createSumType(variants: SumTypeVariant[]): AlgebraicType {
+    let type = new AlgebraicType();
+    type.sum = new SumType(variants);
+    return type;
+  }
+
+  public static createArrayType(elementType: AlgebraicType): AlgebraicType {
+    let type = new AlgebraicType();
+    type.array = elementType;
+    return type;
+  }
+
+  public static createMapType(
+    key: AlgebraicType,
+    val: AlgebraicType
+  ): AlgebraicType {
+    let type = new AlgebraicType();
+    type.map = new MapType(key, val);
+    return type;
+  }
+
+  public static createBoolType(): AlgebraicType {
+    return this.createType(Type.Bool, null);
+  }
+  public static createI8Type(): AlgebraicType {
+    return this.createType(Type.I8, null);
+  }
+  public static createU8Type(): AlgebraicType {
+    return this.createType(Type.U8, null);
+  }
+  public static createI16Type(): AlgebraicType {
+    return this.createType(Type.I16, null);
+  }
+  public static createU16Type(): AlgebraicType {
+    return this.createType(Type.U16, null);
+  }
+  public static createI32Type(): AlgebraicType {
+    return this.createType(Type.I32, null);
+  }
+  public static createU32Type(): AlgebraicType {
+    return this.createType(Type.U32, null);
+  }
+  public static createI64Type(): AlgebraicType {
+    return this.createType(Type.I64, null);
+  }
+  public static createU64Type(): AlgebraicType {
+    return this.createType(Type.U64, null);
+  }
+  public static createI128Type(): AlgebraicType {
+    return this.createType(Type.I128, null);
+  }
+  public static createU128Type(): AlgebraicType {
+    return this.createType(Type.U128, null);
+  }
+  public static createF32Type(): AlgebraicType {
+    return this.createType(Type.F32, null);
+  }
+  public static createF64Type(): AlgebraicType {
+    return this.createType(Type.F64, null);
+  }
+  public static createStringType(): AlgebraicType {
+    return this.createType(Type.String, null);
+  }
+  public static createBytesType(): AlgebraicType {
+    return this.createArrayType(this.createU8Type());
+  }
+
+  public isProductType(): boolean {
+    return this.type === Type.Product;
+  }
+
+  public isSumType(): boolean {
+    return this.type === Type.Sum;
+  }
+
+  public isArrayType(): boolean {
+    return this.type === Type.Array;
+  }
+
+  public isMapType(): boolean {
+    return this.type === Type.Map;
   }
 }
 
-// exporting BuiltinType as a namespace as well as a class allows to add
-// export types on the namespace, so we can use BuiltinType.Type
-/*
-* Represents the built-in types in SATS.
-*
-* Some of these types are nominal in our otherwise structural type system.
-*/
-export namespace BuiltinType {
+export namespace AlgebraicType {
   export enum Type {
+    Sum = "SumType",
+    Product = "ProductType",
+    /** This is a SATS `ArrayType`
+     *
+     * An array type is a **homogeneous** product type of dynamic length.
+     *
+     * That is, it is a product type
+     * where every element / factor / field is of the same type
+     * and where the length is statically unknown.
+     */
+    Array = "Array",
+    /** This is a SATS `MapType` */
+    Map = "Map",
     Bool = "Bool",
     I8 = "I8",
     U8 = "U8",
@@ -156,111 +305,6 @@ export namespace BuiltinType {
     F64 = "F64",
     /** UTF-8 encoded */
     String = "String",
-    /** This is a SATS `ArrayType`
-      * 
-      * An array type is a **homogeneous** product type of dynamic length.
-      *
-      * That is, it is a product type
-      * where every element / factor / field is of the same type
-      * and where the length is statically unknown.
-     */
-    Array = "Array",
-    /** This is a SATS `MapType` */
-    Map = "Map",
-  }
-}
-
-type TypeRef = null;
-type None = null;
-export type EnumLabel = { label: string };
-
-type AnyType = ProductType | SumType | BuiltinType | EnumLabel | TypeRef | None;
-
-/**
-* The SpacetimeDB Algebraic Type System (SATS) is a structural type system in
-* which a nominal type system can be constructed.
-*
-* The type system unifies the concepts sum types, product types, and built-in
-* primitive types into a single type system.
-*/
-export class AlgebraicType {
-  type!: Type;
-  type_?: AnyType;
-
-  public get product(): ProductType {
-    if (this.type !== Type.ProductType) {
-      throw "product type was requested, but the type is not ProductType";
-    }
-    return this.type_ as ProductType;
-  }
-
-  public set product(value: ProductType | undefined) {
-    this.type_ = value;
-    this.type = value == undefined ? Type.None : Type.ProductType;
-  }
-
-  public get sum(): SumType {
-    if (this.type !== Type.SumType) {
-      throw "sum type was requested, but the type is not SumType";
-    }
-    return this.type_ as SumType;
-  }
-  public set sum(value: SumType | undefined) {
-    this.type_ = value;
-    this.type = value == undefined ? Type.None : Type.SumType;
-  }
-
-  public get builtin(): BuiltinType {
-    if (this.type !== Type.BuiltinType) {
-      throw "builtin type was requested, but the type is not BuiltinType";
-    }
-    return this.type_ as BuiltinType;
-  }
-  public set builtin(value: BuiltinType | undefined) {
-    this.type_ = value;
-    this.type = value == undefined ? Type.None : Type.BuiltinType;
-  }
-
-  public static createProductType(
-    elements: ProductTypeElement[]
-  ): AlgebraicType {
-    let type = new AlgebraicType();
-    type.product = new ProductType(elements);
-    return type;
-  }
-
-  public static createArrayType(elementType: AlgebraicType) {
-    let type = new AlgebraicType();
-    type.builtin = new BuiltinType(BuiltinType.Type.Array, elementType);
-    return type;
-  }
-
-  public static createSumType(variants: SumTypeVariant[]): AlgebraicType {
-    let type = new AlgebraicType();
-    type.sum = new SumType(variants);
-    return type;
-  }
-
-  public static createPrimitiveType(type: BuiltinType.Type) {
-    let algebraicType = new AlgebraicType();
-    algebraicType.builtin = new BuiltinType(type, undefined);
-    return algebraicType;
-  }
-
-  public isProductType(): boolean {
-    return this.type === Type.ProductType;
-  }
-
-  public isSumType(): boolean {
-    return this.type === Type.SumType;
-  }
-}
-
-export namespace AlgebraicType {
-  export enum Type {
-    SumType = "SumType",
-    ProductType = "ProductType",
-    BuiltinType = "BuiltinType",
     None = "None",
   }
 }

--- a/src/algebraic_value.ts
+++ b/src/algebraic_value.ts
@@ -1,11 +1,4 @@
-import {
-  ProductType,
-  SumType,
-  AlgebraicType,
-  BuiltinType,
-  // EnumLabel,
-  MapType,
-} from "./algebraic_type";
+import { ProductType, SumType, AlgebraicType, MapType } from "./algebraic_type";
 import BinaryReader from "./binary_reader";
 
 export interface ReducerArgsAdapter {
@@ -43,20 +36,14 @@ export class BinaryReducerArgsAdapter {
   }
 }
 
-/** Defines the interface for deserialize `AlgebraicValue`s*/
+/** Defines the interface for deserializing `AlgebraicValue`s*/
 export interface ValueAdapter {
-  readUInt8Array: () => Uint8Array;
-  readArray: (type: AlgebraicType) => AlgebraicValue[];
-  readMap: (
-    keyType: AlgebraicType,
-    valueType: AlgebraicType
-  ) => Map<AlgebraicValue, AlgebraicValue>;
-  readString: () => string;
   readSum: (type: SumType) => SumValue;
   readProduct: (type: ProductType) => ProductValue;
-
+  readUInt8Array: () => Uint8Array;
+  readArray: (type: AlgebraicType) => AlgebraicValue[];
+  readMap: (keyType: AlgebraicType, valueType: AlgebraicType) => MapValue;
   readBool: () => boolean;
-  readByte: () => number;
   readI8: () => number;
   readU8: () => number;
   readI16: () => number;
@@ -69,6 +56,8 @@ export interface ValueAdapter {
   readI128: () => BigInt;
   readF32: () => number;
   readF64: () => number;
+  readString: () => string;
+  readByte: () => number;
 
   callMethod<K extends keyof ValueAdapter>(methodName: K): any;
 }
@@ -305,10 +294,10 @@ export class JSONAdapter implements ValueAdapter {
 export class SumValue {
   /** A tag representing the choice of one variant of the sum type's variants. */
   public tag: number;
-  /** 
-  * Given a variant `Var(Ty)` in a sum type `{ Var(Ty), ... }`,
-  * this provides the `value` for `Ty`.
-  */
+  /**
+   * Given a variant `Var(Ty)` in a sum type `{ Var(Ty), ... }`,
+   * this provides the `value` for `Ty`.
+   */
   public value: AlgebraicValue;
 
   constructor(tag: number, value: AlgebraicValue) {
@@ -329,12 +318,12 @@ export class SumValue {
   }
 }
 
-/** 
-* A product value is made of a list of
-* "elements" / "fields" / "factors" of other `AlgebraicValue`s.
-*
-* The type of product value is a [product type](`ProductType`).
-*/
+/**
+ * A product value is made of a list of
+ * "elements" / "fields" / "factors" of other `AlgebraicValue`s.
+ *
+ * The type of product value is a [product type](`ProductType`).
+ */
 export class ProductValue {
   elements: AlgebraicValue[];
 
@@ -354,122 +343,29 @@ export class ProductValue {
   }
 }
 
-/** A built-in value of a [`BuiltinType`]. */
-type BuiltinValueType =
+type MapValue = Map<AlgebraicValue, AlgebraicValue>;
+
+type AnyValue =
+  | SumValue
+  | ProductValue
   | boolean
   | string
   | number
   | AlgebraicValue[]
   | BigInt
-  | Map<AlgebraicValue, AlgebraicValue>
+  | MapValue
   | Uint8Array;
-
-export class BuiltinValue {
-  value: BuiltinValueType;
-
-  constructor(value: BuiltinValueType) {
-    this.value = value;
-  }
-
-  public static deserialize(
-    type: BuiltinType,
-    adapter: ValueAdapter
-  ): BuiltinValue {
-    switch (type.type) {
-      case BuiltinType.Type.Array:
-        let arrayBuiltinType: BuiltinType.Type | undefined =
-          type.arrayType &&
-          type.arrayType.type === AlgebraicType.Type.BuiltinType
-            ? type.arrayType.builtin.type
-            : undefined;
-        if (
-          arrayBuiltinType !== undefined &&
-          arrayBuiltinType === BuiltinType.Type.U8
-        ) {
-          const value = adapter.readUInt8Array();
-          return new this(value);
-        } else {
-          const arrayResult = adapter.readArray(
-            type.arrayType as AlgebraicType
-          );
-          return new this(arrayResult);
-        }
-      case BuiltinType.Type.Map:
-        let keyType: AlgebraicType = (type.mapType as MapType).keyType;
-        let valueType: AlgebraicType = (type.mapType as MapType).valueType;
-        const mapResult = adapter.readMap(keyType, valueType);
-        return new this(mapResult);
-      case BuiltinType.Type.String:
-        const result = adapter.readString();
-        return new this(result);
-      default:
-        const methodName: string = "read" + type.type;
-        return new this(adapter.callMethod(methodName as keyof ValueAdapter));
-    }
-  }
-
-  public asString(): string {
-    return this.value as string;
-  }
-
-  public asArray(): AlgebraicValue[] {
-    return this.value as AlgebraicValue[];
-  }
-
-  public asJsArray(type: string): any[] {
-    return this.asArray().map((el) =>
-      el.callMethod(("as" + type) as keyof AlgebraicValue)
-    );
-  }
-
-  public asNumber(): number {
-    return this.value as number;
-  }
-
-  public asBool(): boolean {
-    return this.value as boolean;
-  }
-
-  public asBigInt(): BigInt {
-    return this.value as BigInt;
-  }
-
-  public asBoolean(): boolean {
-    return this.value as boolean;
-  }
-
-  public asBytes(): Uint8Array {
-    return this.value as Uint8Array;
-  }
-}
-
-type AnyValue = SumValue | ProductValue | BuiltinValue;
 
 /** A value in SATS. */
 export class AlgebraicValue {
-  /** A structural sum value. */
-  sum: SumValue | undefined;
-  /** A structural product value. */
-  product: ProductValue | undefined;
-  /** A builtin value that has a builtin type */
-  builtin: BuiltinValue | undefined;
+  value: AnyValue;
 
   constructor(value: AnyValue | undefined) {
     if (value === undefined) {
       // TODO: possibly get rid of it
       throw "value is undefined";
     }
-    switch (value.constructor) {
-      case SumValue:
-        this.sum = value as SumValue;
-        break;
-      case ProductValue:
-        this.product = value as ProductValue;
-        break;
-      case BuiltinValue:
-        this.builtin = value as BuiltinValue;
-        break;
-    }
+    this.value = value;
   }
 
   callMethod<K extends keyof AlgebraicValue>(methodName: K): any {
@@ -478,75 +374,88 @@ export class AlgebraicValue {
 
   public static deserialize(type: AlgebraicType, adapter: ValueAdapter) {
     switch (type.type) {
-      case AlgebraicType.Type.ProductType:
-        return new this(ProductValue.deserialize(type.product, adapter));
-      case AlgebraicType.Type.SumType:
+      case AlgebraicType.Type.Sum:
         return new this(SumValue.deserialize(type.sum, adapter));
-      case AlgebraicType.Type.BuiltinType:
-        return new this(BuiltinValue.deserialize(type.builtin, adapter));
+      case AlgebraicType.Type.Product:
+        return new this(ProductValue.deserialize(type.product, adapter));
+      case AlgebraicType.Type.Array:
+        let elemType = type.array;
+        if (elemType.type === AlgebraicType.Type.U8) {
+          return new this(adapter.readUInt8Array());
+        } else {
+          return new this(adapter.readArray(elemType));
+        }
+      case AlgebraicType.Type.Map:
+        let mapType = type.map;
+        return new this(adapter.readMap(mapType.keyType, mapType.valueType));
+      case AlgebraicType.Type.Bool:
+        return new this(adapter.readBool());
+      case AlgebraicType.Type.I8:
+        return new this(adapter.readI8());
+      case AlgebraicType.Type.U8:
+        return new this(adapter.readU8());
+      case AlgebraicType.Type.I16:
+        return new this(adapter.readI16());
+      case AlgebraicType.Type.U16:
+        return new this(adapter.readU16());
+      case AlgebraicType.Type.I32:
+        return new this(adapter.readI32());
+      case AlgebraicType.Type.U32:
+        return new this(adapter.readU32());
+      case AlgebraicType.Type.I64:
+        return new this(adapter.readI64());
+      case AlgebraicType.Type.U64:
+        return new this(adapter.readU64());
+      case AlgebraicType.Type.I128:
+        return new this(adapter.readI128());
+      case AlgebraicType.Type.U128:
+        return new this(adapter.readU128());
+      case AlgebraicType.Type.String:
+        return new this(adapter.readString());
       default:
-        throw new Error("not implemented");
+        throw new Error(`not implemented, ${type.type}`);
     }
-  }
-
-  public asProductValue(): ProductValue {
-    if (!this.product) {
-      throw "AlgebraicValue is not a ProductValue and product was requested";
-    }
-    return this.product as ProductValue;
-  }
-
-  public asBuiltinValue(): BuiltinValue {
-    this.assertBuiltin();
-    return this.builtin as BuiltinValue;
   }
 
   public asSumValue(): SumValue {
-    if (!this.sum) {
-      throw "AlgebraicValue is not a SumValue and a sum value was requested";
-    }
+    return this.value as SumValue;
+  }
 
-    return this.sum as SumValue;
+  public asProductValue(): ProductValue {
+    return this.value as ProductValue;
   }
 
   public asArray(): AlgebraicValue[] {
-    this.assertBuiltin();
-    return (this.builtin as BuiltinValue).asArray();
+    return this.value as AlgebraicValue[];
   }
 
-  public asString(): string {
-    this.assertBuiltin();
-    return (this.builtin as BuiltinValue).asString();
-  }
-
-  public asNumber(): number {
-    this.assertBuiltin();
-    return (this.builtin as BuiltinValue).asNumber();
+  public asMap(): MapValue {
+    return this.value as MapValue;
   }
 
   public asBool(): boolean {
-    this.assertBuiltin();
-    return (this.builtin as BuiltinValue).asBool();
+    return this.value as boolean;
+  }
+
+  public asNumber(): number {
+    return this.value as number;
   }
 
   public asBigInt(): BigInt {
-    this.assertBuiltin();
-    return (this.builtin as BuiltinValue).asBigInt();
+    return this.value as BigInt;
   }
 
-  public asBoolean(): boolean {
-    this.assertBuiltin();
-    return (this.builtin as BuiltinValue).asBool();
+  public asString(): string {
+    return this.value as string;
   }
 
   public asBytes(): Uint8Array {
-    this.assertBuiltin();
-    return (this.builtin as BuiltinValue).asBytes();
+    return this.value as Uint8Array;
   }
 
-  private assertBuiltin() {
-    if (!this.builtin) {
-      throw "AlgebraicValue is not a BuiltinValue and a string was requested";
-    }
+  public asJsArray(type: string): any[] {
+    return this.asArray().map((el) =>
+      el.callMethod(("as" + type) as keyof AlgebraicValue)
+    );
   }
 }

--- a/src/spacetimedb.ts
+++ b/src/spacetimedb.ts
@@ -21,7 +21,6 @@ import {
   ProductTypeElement,
   SumType,
   SumTypeVariant,
-  BuiltinType,
 } from "./algebraic_type";
 import { EventType } from "./types";
 import { Identity } from "./identity";
@@ -42,7 +41,6 @@ export {
   ProductTypeElement,
   SumType,
   SumTypeVariant,
-  BuiltinType,
   ProtobufMessage,
   BinarySerializer,
 };

--- a/tests/algebraic_value.test.ts
+++ b/tests/algebraic_value.test.ts
@@ -2,13 +2,11 @@ import {
   AlgebraicType,
   ProductType,
   ProductTypeElement,
-  BuiltinType,
 } from "../src/algebraic_type";
 import {
   ProductValue,
   AlgebraicValue,
   SumValue,
-  BuiltinValue,
   BinaryAdapter,
   JSONAdapter,
 } from "../src/algebraic_value";
@@ -19,57 +17,38 @@ describe("AlgebraicValue", () => {
     let value = new ProductValue([]);
     let av = new AlgebraicValue(value);
 
-    expect(av.product).toBe(value);
     expect(av.asProductValue()).toBe(value);
   });
 
   test("when created with a SumValue it assigns the sum property", () => {
-    let value = new SumValue(1, new AlgebraicValue(new BuiltinValue(1)));
+    let value = new SumValue(1, new AlgebraicValue(1));
     let av = new AlgebraicValue(value);
 
-    expect(av.sum).toBe(value);
     expect(av.asSumValue()).toBe(value);
   });
 
-  test("when created with a BuiltinValue it assigns the builtin property", () => {
-    let value = new BuiltinValue(1);
-    let av = new AlgebraicValue(value);
-
-    expect(av.builtin).toBe(value);
-    expect(av.asBuiltinValue()).toBe(value);
-  });
-
-  test("when created with a BuiltinValue(string) it can be requested as a string", () => {
-    let value = new BuiltinValue("foo");
-    let av = new AlgebraicValue(value);
+  test("when created with a AlgebraicValue(string) it can be requested as a string", () => {
+    let av = new AlgebraicValue("foo");
 
     expect(av.asString()).toBe("foo");
   });
 
-  test("when created with a BuiltinValue(AlgebraicValue[]) it can be requested as an array", () => {
-    let array: AlgebraicValue[] = [new AlgebraicValue(new BuiltinValue(1))];
-    let value = new BuiltinValue(array);
-    let av = new AlgebraicValue(value);
+  test("when created with a AlgebraicValue(AlgebraicValue[]) it can be requested as an array", () => {
+    let array: AlgebraicValue[] = [new AlgebraicValue(1)];
+    let av = new AlgebraicValue(array);
 
     expect(av.asArray()).toBe(array);
   });
 });
 
-describe("BuiltinValue", () => {
+describe("primitive values", () => {
   describe("deserialize with a binary adapter", () => {
     test("should correctly deserialize array with U8 type", () => {
       const input = new Uint8Array([2, 0, 0, 0, 10, 20]);
       const reader = new BinaryReader(input);
       const adapter: BinaryAdapter = new BinaryAdapter(reader);
-      const elementType = AlgebraicType.createPrimitiveType(
-        BuiltinType.Type.U8
-      );
-      const type: BuiltinType = new BuiltinType(
-        BuiltinType.Type.Array,
-        elementType
-      );
-
-      const result = BuiltinValue.deserialize(type, adapter);
+      const type = AlgebraicType.createBytesType();
+      const result = AlgebraicValue.deserialize(type, adapter);
 
       expect(result.asBytes()).toEqual(new Uint8Array([10, 20]));
     });
@@ -85,15 +64,8 @@ describe("BuiltinValue", () => {
       ]);
       const reader = new BinaryReader(input);
       const adapter: BinaryAdapter = new BinaryAdapter(reader);
-      const elementType = AlgebraicType.createPrimitiveType(
-        BuiltinType.Type.U128
-      );
-      const type: BuiltinType = new BuiltinType(
-        BuiltinType.Type.Array,
-        elementType
-      );
-
-      const result = BuiltinValue.deserialize(type, adapter);
+      const type = AlgebraicType.createArrayType(AlgebraicType.createU128Type());
+      const result = AlgebraicValue.deserialize(type, adapter);
 
       const u128_max = BigInt(2) ** BigInt(128) - BigInt(1);
       expect(result.asJsArray("BigInt")).toEqual([
@@ -111,8 +83,8 @@ describe("BuiltinValue", () => {
       ]);
       const reader = new BinaryReader(input);
       const adapter: BinaryAdapter = new BinaryAdapter(reader);
-      const result = BuiltinValue.deserialize(
-        new BuiltinType(BuiltinType.Type.U128, undefined),
+      const result = AlgebraicValue.deserialize(
+        AlgebraicType.createU128Type(),
         adapter
       );
 
@@ -125,8 +97,8 @@ describe("BuiltinValue", () => {
       const input = new Uint8Array([1]);
       const reader = new BinaryReader(input);
       const adapter: BinaryAdapter = new BinaryAdapter(reader);
-      const result = BuiltinValue.deserialize(
-        new BuiltinType(BuiltinType.Type.Bool, undefined),
+      const result = AlgebraicValue.deserialize(
+        AlgebraicType.createBoolType(),
         adapter
       );
 
@@ -145,8 +117,8 @@ describe("BuiltinValue", () => {
 
       const reader = new BinaryReader(input);
       const adapter: BinaryAdapter = new BinaryAdapter(reader);
-      const result = BuiltinValue.deserialize(
-        new BuiltinType(BuiltinType.Type.String, undefined),
+      const result = AlgebraicValue.deserialize(
+        AlgebraicType.createStringType(),
         adapter
       );
 
@@ -158,15 +130,8 @@ describe("BuiltinValue", () => {
     test("should correctly deserialize array with U8 type", () => {
       const value = "0002FF";
       const adapter: JSONAdapter = new JSONAdapter(value);
-      const elementType = AlgebraicType.createPrimitiveType(
-        BuiltinType.Type.U8
-      );
-      const type: BuiltinType = new BuiltinType(
-        BuiltinType.Type.Array,
-        elementType
-      );
-
-      const result = BuiltinValue.deserialize(type, adapter);
+      const type = AlgebraicType.createBytesType();
+      const result = AlgebraicValue.deserialize(type, adapter);
 
       expect(result.asBytes()).toEqual(new Uint8Array([0, 2, 255]));
     });
@@ -175,15 +140,8 @@ describe("BuiltinValue", () => {
       const u128_max = BigInt(2) ** BigInt(128) - BigInt(1);
       const value = [BigInt(1), u128_max, BigInt(10)];
       const adapter: JSONAdapter = new JSONAdapter(value);
-      const elementType = AlgebraicType.createPrimitiveType(
-        BuiltinType.Type.U128
-      );
-      const type: BuiltinType = new BuiltinType(
-        BuiltinType.Type.Array,
-        elementType
-      );
-
-      const result = BuiltinValue.deserialize(type, adapter);
+      const type = AlgebraicType.createArrayType(AlgebraicType.createU128Type());
+      const result = AlgebraicValue.deserialize(type, adapter);
 
       expect(result.asJsArray("BigInt")).toEqual([
         BigInt(1),
@@ -195,8 +153,8 @@ describe("BuiltinValue", () => {
     test("should correctly deserialize an U128 type", () => {
       const value = BigInt("123456789123456789");
       const adapter: JSONAdapter = new JSONAdapter(value);
-      const result = BuiltinValue.deserialize(
-        new BuiltinType(BuiltinType.Type.U128, undefined),
+      const result = AlgebraicValue.deserialize(
+        AlgebraicType.createU128Type(),
         adapter
       );
 
@@ -205,8 +163,8 @@ describe("BuiltinValue", () => {
 
     test("should correctly deserialize a boolean type", () => {
       const adapter: JSONAdapter = new JSONAdapter(true);
-      const result = BuiltinValue.deserialize(
-        new BuiltinType(BuiltinType.Type.Bool, undefined),
+      const result = AlgebraicValue.deserialize(
+        AlgebraicType.createBoolType(),
         adapter
       );
 
@@ -216,8 +174,8 @@ describe("BuiltinValue", () => {
     test("should correctly deserialize a string type", () => {
       const text = "zażółć gęślą jaźń";
       const adapter: JSONAdapter = new JSONAdapter(text);
-      const result = BuiltinValue.deserialize(
-        new BuiltinType(BuiltinType.Type.String, undefined),
+      const result = AlgebraicValue.deserialize(
+        AlgebraicType.createStringType(),
         adapter
       );
 

--- a/tests/types/create_player_reducer.ts
+++ b/tests/types/create_player_reducer.ts
@@ -6,7 +6,6 @@ import {
   __SPACETIMEDB__,
   AlgebraicType,
   ProductType,
-  BuiltinType,
   ProductTypeElement,
   IDatabaseTable,
   AlgebraicValue,
@@ -21,7 +20,7 @@ export class CreatePlayerReducer {
   public static call(name: string, location: Point) {}
 
   public static deserializeArgs(adapter: ReducerArgsAdapter): any[] {
-    let nameType = AlgebraicType.createPrimitiveType(BuiltinType.Type.String);
+    let nameType = AlgebraicType.createStringType();
     let nameValue = AlgebraicValue.deserialize(nameType, adapter.next());
     let name = nameValue.asString();
     let locationType = Point.getAlgebraicType();

--- a/tests/types/player.ts
+++ b/tests/types/player.ts
@@ -6,7 +6,6 @@ import {
   __SPACETIMEDB__,
   AlgebraicType,
   ProductType,
-  BuiltinType,
   ProductTypeElement,
   SumType,
   SumTypeVariant,
@@ -40,11 +39,11 @@ export class Player extends IDatabaseTable {
     return AlgebraicType.createProductType([
       new ProductTypeElement(
         "owner_id",
-        AlgebraicType.createPrimitiveType(BuiltinType.Type.String)
+        AlgebraicType.createStringType()
       ),
       new ProductTypeElement(
         "name",
-        AlgebraicType.createPrimitiveType(BuiltinType.Type.String)
+        AlgebraicType.createStringType()
       ),
       new ProductTypeElement("location", Point.getAlgebraicType()),
     ]);

--- a/tests/types/point.ts
+++ b/tests/types/point.ts
@@ -6,7 +6,6 @@ import {
   __SPACETIMEDB__,
   AlgebraicType,
   ProductType,
-  BuiltinType,
   ProductTypeElement,
   SumType,
   SumTypeVariant,
@@ -36,11 +35,11 @@ export class Point extends IDatabaseTable {
     return AlgebraicType.createProductType([
       new ProductTypeElement(
         "x",
-        AlgebraicType.createPrimitiveType(BuiltinType.Type.U16)
+        AlgebraicType.createU16Type()
       ),
       new ProductTypeElement(
         "y",
-        AlgebraicType.createPrimitiveType(BuiltinType.Type.U16)
+        AlgebraicType.createU16Type()
       ),
     ]);
   }

--- a/tests/types/user.ts
+++ b/tests/types/user.ts
@@ -6,7 +6,6 @@ import {
   __SPACETIMEDB__,
   AlgebraicType,
   ProductType,
-  BuiltinType,
   ProductTypeElement,
   SumType,
   SumTypeVariant,
@@ -40,15 +39,13 @@ export class User extends IDatabaseTable {
         AlgebraicType.createProductType([
           new ProductTypeElement(
             "__identity_bytes",
-            AlgebraicType.createArrayType(
-              AlgebraicType.createPrimitiveType(BuiltinType.Type.U8)
-            )
+            AlgebraicType.createBytesType()
           ),
         ])
       ),
       new ProductTypeElement(
         "username",
-        AlgebraicType.createPrimitiveType(BuiltinType.Type.String)
+        AlgebraicType.createStringType()
       ),
     ]);
   }


### PR DESCRIPTION
## Description of Changes

1. Flattens `AlgebraicType` and `AlgebraicValue` in line with planned spacetimedb changes.
2. Adds convenience functionality and functions to make the typescript SDK nicer to work with.

## API

 - [x] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*

Substantial parts of `AlgebraicType` and `AlgebraicValue` is now different. See the diff for more details.

## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*

Counter PR: https://github.com/clockworklabs/SpacetimeDB/pull/379