### PR TITLE
Fix identity constructor

### DIFF
--- a/src/identity.ts
+++ b/src/identity.ts
@@ -21,13 +21,13 @@ export class Identity {
   /**
    * Creates a new `Identity`.
    */
-  constructor(data: { __identity_bytes: string } | Uint8Array) {
+  constructor(data: string | Uint8Array) {
     // we get a JSON with __identity_bytes when getting a token with a JSON API
     // and an Uint8Array when using BSATN
     this.data =
       data.constructor === Uint8Array
         ? uint8ArrayToHexString(data as Uint8Array)
-        : (data as { __identity_bytes: string }).__identity_bytes;
+        : (data as string);
   }
 
   /**
@@ -52,6 +52,6 @@ export class Identity {
    * Parse an Identity from a hexadecimal string.
    */
   static fromString(str: string): Identity {
-    return new Identity({ __identity_bytes: str });
+    return new Identity(str);
   }
 }

--- a/tests/spacetimedb_client.test.ts
+++ b/tests/spacetimedb_client.test.ts
@@ -67,6 +67,7 @@ describe("SpacetimeDBClient", () => {
         IdentityToken: {
           identity: "an-identity",
           token: "a-token",
+          address: "00FF00",
         },
       },
     };
@@ -100,6 +101,7 @@ describe("SpacetimeDBClient", () => {
         IdentityToken: {
           identity: "an-identity",
           token: "a-token",
+          address: "00FF00",
         },
       },
     };
@@ -150,6 +152,7 @@ describe("SpacetimeDBClient", () => {
           timestamp: 1681391805281203,
           status: "committed",
           caller_identity: "00FF01",
+          caller_address: "00FF00",
           function_call: {
             reducer: "create_player",
             args: '["A Player",[0.2, 0.3]]',
@@ -221,6 +224,7 @@ describe("SpacetimeDBClient", () => {
         IdentityToken: {
           identity: "an-identity",
           token: "a-token",
+          address: "00FF00",
         },
       },
     };
@@ -267,7 +271,8 @@ describe("SpacetimeDBClient", () => {
         event: {
           timestamp: 1681391805281203,
           status: "committed",
-          caller_identity: "identity-0",
+          caller_identity: "00FF01",
+          caller_address: "00FF00",
           function_call: {
             reducer: "create_player",
             args: '["A Player",[0.2, 0.3]]',
@@ -336,7 +341,8 @@ describe("SpacetimeDBClient", () => {
         event: {
           timestamp: 1681391805281203,
           status: "committed",
-          caller_identity: "identity-0",
+          caller_identity: "00FF01",
+          caller_address: "00FF00",
           function_call: {
             reducer: "create_player",
             args: '["A Player",[0.2, 0.3]]',
@@ -391,6 +397,7 @@ describe("SpacetimeDBClient", () => {
         IdentityToken: {
           identity: "an-identity",
           token: "a-token",
+          address: "00FF00",
         },
       },
     };
@@ -443,7 +450,8 @@ describe("SpacetimeDBClient", () => {
         event: {
           timestamp: 1681391805281203,
           status: "committed",
-          caller_identity: "identity-0",
+          caller_identity: "00FF01",
+          caller_address: "00FF00",
           function_call: {
             reducer: "create_user",
             args: '["A User",[0.2, 0.3]]',


### PR DESCRIPTION
At some point identities were returned in a form of { __identity_bytes: string } object. This commit changes the implementation to accept regular strings as an argument because that's how we get all of the identities now.

## Description of Changes
*Describe what has been changed, any new features or bug fixes*

## API

 - [ ] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*


## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*
