### PR TITLE
Fix type returned by DatabaseTable.with method

### DIFF
--- a/src/database_table.ts
+++ b/src/database_table.ts
@@ -19,9 +19,10 @@ export class DatabaseTable {
   public static tableName: string;
 
   public static with<T extends DatabaseTable>(
+    this: T,
     client: SpacetimeDBClient
-  ): ThisType<T> {
-    return _tableProxy<T>(this, client) as unknown as ThisType<T>;
+  ): T {
+    return _tableProxy<T>(this, client) as unknown as T;
   }
 
   public static getDB(): ClientDB {

--- a/tests/spacetimedb_client.test.ts
+++ b/tests/spacetimedb_client.test.ts
@@ -508,4 +508,23 @@ describe("SpacetimeDBClient", () => {
     expect(updates[1]["oldUser"].username).toBe("jaime");
     expect(updates[1]["newUser"].username).toBe("kingslayer");
   });
+
+  test("Filtering works", async () => {
+    const client = new SpacetimeDBClient(
+      "ws://127.0.0.1:1234",
+      "db",
+      undefined,
+      "json"
+    );
+    const db = client.db;
+    const user1 = new User(new Identity("bobs-idenitty"), "bob");
+    const user2 = new User(new Identity("sallys-identity"), "sally");
+    const users = db.getTable("User").instances;
+    users.set("abc123", user1);
+    users.set("def456", user2);
+
+    const filteredUsers = User.with(client).filterByUsername("sally");
+    expect(filteredUsers).toHaveLength(1);
+    expect(filteredUsers[0].username).toBe("sally");
+  });
 });


### PR DESCRIPTION
## Description of Changes

This PR fixes the `with` method available on database tables, which allows to call methods on the table with multiple clients

## API

 - [ ] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*


## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*
