### PR TITLE
Fix issue where some Typescript based project transpiler might mangle the table or Reducer

### DIFF
--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -1,7 +1,11 @@
 import { SpacetimeDBClient } from "./spacetimedb";
 
-export type ReducerClass = { new (...args: any[]): Reducer };
+export type ReducerClass = {
+  new (...args: any[]): Reducer;
+  reducerName: string;
+};
 export class Reducer {
+  public static reducerName: string;
   public call(..._args: any[]): void {
     throw "not implemented";
   }

--- a/src/spacetimedb.ts
+++ b/src/spacetimedb.ts
@@ -820,12 +820,12 @@ export class SpacetimeDBClient {
    * @param component Component to be registered
    */
   public static registerTable(table: DatabaseTableClass) {
-    this.tableClasses.set(table.name, table);
+    this.tableClasses.set(table.tableName, table);
   }
 
   public static registerTables(...tables: DatabaseTableClass[]) {
     for (const table of tables) {
-      this.tableClasses.set(table.name, table);
+      this.registerTable(table);
     }
   }
 
@@ -836,14 +836,15 @@ export class SpacetimeDBClient {
    * @param reducer Reducer to be registered
    */
   public static registerReducer(reducer: ReducerClass) {
-    this.reducerClasses.set(reducer.name, reducer);
+    this.reducerClasses.set(reducer.reducerName + "Reducer", reducer);
   }
 
   public static registerReducers(...reducers: ReducerClass[]) {
     for (const reducer of reducers) {
-      this.reducerClasses.set(reducer.name, reducer);
+      this.registerReducer(reducer);
     }
   }
+
   /**
    * Subscribe to a set of queries, to be notified when rows which match those queries are altered.
    *


### PR DESCRIPTION
Related to this issues, clockworklabs/spacetimedb-typescript-sdk/issues/31

This commit change the way the table and reducer are registered to prevent an error message like `Could not find class "Person", you need to register it with SpacetimeDBClient.registerTable() first` to happen.

Some Typescript based project change the name of the classes when beging converted into javaScript. This behavior prevent the Tables and Reducer to be registered with the right name.

I used the name who are found in the auto generated TypeScript code.
reducer.reducerName for the reducer and table.tableName for the tables

