### PR TITLE
Bump version to 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clockworklabs/spacetimedb-sdk",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "SDK for SpacetimeDB",
   "author": {
     "name": "Clockwork Labs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clockworklabs/spacetimedb-sdk",
-  "version": "0.9.0",
+  "version": "0.9.2",
   "description": "SDK for SpacetimeDB",
   "author": {
     "name": "Clockwork Labs",


### PR DESCRIPTION
## Description of Changes
Bump the version number to 0.10.0 in coordination with the release.

## API

 - [ ] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*


## Requires SpacetimeDB PRs
I don't know, but corresponding SpacetimeDB PR: https://github.com/clockworklabs/SpacetimeDB/pull/1352