### PR TITLE
modernize: in-house EventEmitter

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -16,10 +16,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": {
-        "production": "./dist/min/index.js",
-        "development": "./dist/index.js"
-      },
+      "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
@@ -42,7 +39,6 @@
   "dependencies": {
     "brotli": "1.3.3",
     "buffer": "^6.0.3",
-    "events": "^3.3.0",
     "isomorphic-ws": "^5.0.0",
     "long": "^5.2.3",
     "websocket": "^1.0.34",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -16,7 +16,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
+      "import": {
+        "production": "./dist/min/index.js",
+        "development": "./dist/index.js"
+      },
       "default": "./dist/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/sdk/src/events.ts
+++ b/packages/sdk/src/events.ts
@@ -1,0 +1,31 @@
+export class EventEmitter {
+  #events: Map<string, Set<Function>> = new Map();
+
+  on(event: string, callback: Function) {
+    let callbacks = this.#events.get(event);
+    if (!callbacks) {
+      callbacks = new Set();
+      this.#events.set(event, callbacks);
+    }
+    callbacks.add(callback);
+  }
+
+  off(event: string, callback: Function) {
+    let callbacks = this.#events.get(event);
+    if (!callbacks) {
+      return;
+    }
+    callbacks.delete(callback);
+  }
+
+  emit(event: string, ...args: any[]) {
+    let callbacks = this.#events.get(event);
+    if (!callbacks) {
+      return;
+    }
+
+    for (let callback of callbacks) {
+      callback(...args);
+    }
+  }
+}

--- a/packages/sdk/src/spacetimedb.ts
+++ b/packages/sdk/src/spacetimedb.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from "events";
+import { EventEmitter } from "./events";
 
 import { WebsocketDecompressAdapter } from "./websocket_decompress_adapter";
 import type { WebsocketTestAdapter } from "./websocket_test_adapter";
@@ -30,10 +30,10 @@ import { Identity } from "./identity";
 import { stdbLogger } from "./logger";
 import {
   IdentityTokenMessage,
-  type Message,
   SubscriptionUpdateMessage,
   TransactionUpdateEvent,
   TransactionUpdateMessage,
+  type Message,
 } from "./message_types";
 import { Reducer, type ReducerClass } from "./reducer";
 import { ReducerEvent } from "./reducer_event";
@@ -58,7 +58,6 @@ export {
   type DatabaseTableClass,
   type ReducerClass,
 };
-
 export type { ReducerArgsAdapter, Serializer, ValueAdapter };
 
 const g = (typeof window === "undefined" ? global : window)!;

--- a/packages/sdk/src/table.ts
+++ b/packages/sdk/src/table.ts
@@ -1,6 +1,6 @@
-import { EventEmitter } from "events";
 import { BinaryAdapter } from "./algebraic_value";
 import BinaryReader from "./binary_reader";
+import { EventEmitter } from "./events";
 import OperationsMap from "./operations_map";
 import { ReducerEvent } from "./reducer_event";
 import { AlgebraicValue, DatabaseTable } from "./spacetimedb";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,9 +60,6 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
-      events:
-        specifier: ^3.3.0
-        version: 3.3.0
       isomorphic-ws:
         specifier: ^5.0.0
         version: 5.0.0(ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
@@ -822,10 +819,6 @@ packages:
 
   event-emitter@0.3.5:
     resolution: {integrity: sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==}
-
-  events@3.3.0:
-    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
-    engines: {node: '>=0.8.x'}
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -2280,8 +2273,6 @@ snapshots:
     dependencies:
       d: 1.0.2
       es5-ext: 0.10.64
-
-  events@3.3.0: {}
 
   execa@5.1.1:
     dependencies:


### PR DESCRIPTION
Gets rid of `events` package which does too much. We need only on, off and emit events, which are easily done in our own code