### PR TITLE
Fix: Synchronous WS Processing

### DIFF
--- a/src/websocket_decompress_adapter.ts
+++ b/src/websocket_decompress_adapter.ts
@@ -11,12 +11,10 @@ export class WebsocketDecompressAdapter {
   private ws: WebSocket;
 
   private handleOnMessage(msg: { data: any }) {
-    msg.data.arrayBuffer().then((data: Uint8Array) => {
-      const decompressed = decompress(new Buffer(data));
-      if (this.onmessage) {
-        this.onmessage({ data: decompressed });
-      }
-    });
+    const decompressed = decompress(new Buffer(msg.data));
+    if (this.onmessage) {
+      this.onmessage({ data: decompressed });
+    }
   }
 
   private handleOnClose(msg: any) {
@@ -55,6 +53,8 @@ export class WebsocketDecompressAdapter {
     ws.onerror = this.handleOnError.bind(this);
     ws.onclose = this.handleOnError.bind(this);
     ws.onopen = this.handleOnOpen.bind(this);
+
+    ws.binaryType = 'arraybuffer'
 
     this.ws = ws;
   }


### PR DESCRIPTION
## Issue

@Dynrothe described an issue where rows were not being deleted on FireFox and created a [minimal reproduction](https://github.com/Dynrothe/spacetimedb-ts-bug-demo). 
This was discovered to be due to out of order processing of ws messages which can be seen [here](https://github.com/tcardlab/Dynnys-STDB-bug-demo/tree/investigation):
<Details>
  <Summary><strong>Code Catching Out of Order Messages:</strong></Summary>
  This code will log the received messages first ("msg n"), then the log them as they resolve ("from msg n").
  <img width="831" alt="Screen Shot 2024-08-14 at 1 39 33 AM" src="https://github.com/user-attachments/assets/91e5b215-5327-4775-aca8-a61154129216">
</Details>
<Details>
  <Summary><strong>FireFox Error:</strong></Summary>
  Messages are received in order in accordance with TCP, but resolved out of order.<br/>
  Here you can see an out of oder message (38) is failing to delete a row that has not been inserted yet (37).<br/>
  (this may lead to a build up of old rows on clients)
  <img width="600" alt="Screen Shot 2024-08-14 at 1 37 11 AM" src="https://github.com/user-attachments/assets/1db8d21e-be04-4f3f-bfa8-33cbce4ce5a7">
</Details>



It was fixed by switching to a synchronous binary processing method as described below.


## Description of Changes

Binary WS defaults to using "blob" data types which requires async processing to convert to arrayBuffer. This async process was causing out of order message processing as the conversions to buffers occasionally resolved out of order. This whole process and issue can be avoided by retrieving arrayBuffer directly from the WS via the "binaryType" property.

https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/binaryType


## API

 - [ ] This is an API breaking change to the SDK

## Requires SpacetimeDB PRs
none

## Obligatory Primeagen Tweet
<a href="https://x.com/ThePrimeagen/status/1796262882721587362">
  <img width="477" alt="Screen Shot 2024-08-14 at 1 45 08 AM" src="https://github.com/user-attachments/assets/469597c0-695c-477f-ba93-e6b8364c35da">
</a>

