### PR TITLE
modernize: Single output

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "spacetimedb-ts-sdk",
   "private": true,
   "scripts": {
-    "compile": "pnpm -r compile",
+    "compile": "cd packages/sdk && pnpm compile",
     "format": "prettier --write .",
     "lint": "prettier . --check",
     "test": "pnpm -r test"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -16,10 +16,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": {
-        "production": "./dist/min/index.js",
-        "development": "./dist/index.js"
-      },
+      "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
Removes conditional imports, now it relies only on dist/index.js. This is to avoid ambiguity going from dev mode to prod mode, and any monkey patching someone could've done