### PR TITLE
modernize: Engines field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "spacetimedb-ts-sdk",
   "private": true,
+  "engines": {
+    "node": ">=18.0.0",
+    "pnpm": ">=9.0.0"
+  },
   "scripts": {
     "compile": "cd packages/sdk && pnpm compile",
     "format": "prettier --write .",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -33,6 +33,9 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/clockworklabs"
   },
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "peerDependencies": {
     "undici": "^6.19.2"
   },


### PR DESCRIPTION
Makes sure the SDK isn't used before v18