### PR TITLE
modernize: webpackIgnore undici

### DIFF
--- a/packages/sdk/src/websocket_decompress_adapter.ts
+++ b/packages/sdk/src/websocket_decompress_adapter.ts
@@ -79,7 +79,7 @@ export class WebsocketDecompressAdapter {
       'WebSocket' in globalThis
         ? WebSocket
         : // This weird trick is needed so that bundlers dont try to bundle undici
-          ((await import('und' + 'ici'))
+          ((await import(/* webpackIgnore: true */ 'undici'))
             .WebSocket as unknown as typeof WebSocket);
 
     // In the browser we first have to get a short lived token and only then connect to the websocket

--- a/packages/sdk/src/websocket_decompress_adapter.ts
+++ b/packages/sdk/src/websocket_decompress_adapter.ts
@@ -78,7 +78,9 @@ export class WebsocketDecompressAdapter {
     const WS =
       'WebSocket' in globalThis
         ? WebSocket
-        : ((await import('undici')).WebSocket as unknown as typeof WebSocket);
+        : // This weird trick is needed so that bundlers dont try to bundle undici
+          ((await import('und' + 'ici'))
+            .WebSocket as unknown as typeof WebSocket);
 
     // In the browser we first have to get a short lived token and only then connect to the websocket
     let httpProtocol = params.ssl ? 'https://' : 'http://';


### PR DESCRIPTION
This tells webpack to ignore undici dynamic import so it doesn't trip. I won't prevent other bundlers though, so this is only a hacky solution just for Webpack 4 and Create-React-App