### PR TITLE
modernize: Conditional browser build

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -9,6 +9,7 @@
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
+  "browser": "./dist/browser/index.js",
   "type": "module",
   "files": [
     "dist"
@@ -16,6 +17,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "browser": "./dist/browser/index.js",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },

--- a/packages/sdk/src/websocket_decompress_adapter.ts
+++ b/packages/sdk/src/websocket_decompress_adapter.ts
@@ -83,8 +83,7 @@ export class WebsocketDecompressAdapter {
         'WebSocket' in globalThis
           ? WebSocket
           : // This weird trick is needed so that bundlers dont try to bundle undici
-            ((await import(/* webpackIgnore: true */ 'undici'))
-              .WebSocket as unknown as typeof WebSocket);
+            ((await import('undici')).WebSocket as unknown as typeof WebSocket);
     } else {
       WS = WebSocket;
     }

--- a/packages/sdk/src/websocket_decompress_adapter.ts
+++ b/packages/sdk/src/websocket_decompress_adapter.ts
@@ -75,12 +75,19 @@ export class WebsocketDecompressAdapter {
       );
     }
 
-    const WS =
-      'WebSocket' in globalThis
-        ? WebSocket
-        : // This weird trick is needed so that bundlers dont try to bundle undici
-          ((await import(/* webpackIgnore: true */ 'undici'))
-            .WebSocket as unknown as typeof WebSocket);
+    let WS: typeof WebSocket;
+
+    // @ts-ignore
+    if (import.meta.env.BROWSER === 'false') {
+      WS =
+        'WebSocket' in globalThis
+          ? WebSocket
+          : // This weird trick is needed so that bundlers dont try to bundle undici
+            ((await import(/* webpackIgnore: true */ 'undici'))
+              .WebSocket as unknown as typeof WebSocket);
+    } else {
+      WS = WebSocket;
+    }
 
     // In the browser we first have to get a short lived token and only then connect to the websocket
     let httpProtocol = params.ssl ? 'https://' : 'http://';

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -4,7 +4,6 @@
     "module": "ESNext",
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "dist",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
@@ -15,6 +14,6 @@
     "moduleResolution": "Bundler",
     "allowSyntheticDefaultImports": true
   },
-  "include": ["src"],
+  "include": ["src/**/*"],
   "exclude": ["node_modules", "**/__tests__/*", "dist"]
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -13,9 +13,30 @@ export default defineConfig([
     },
     clean: true,
     platform: 'browser',
-    noExternal: ['brotli', 'buffer', 'events'],
+    noExternal: ['brotli', 'buffer'],
     treeshake: 'smallest',
     external: ['undici'],
+    env: {
+      BROWSER: 'false',
+    },
+  },
+  {
+    entryPoints: {
+      index: 'src/index.ts',
+    },
+    format: ['esm'],
+    target: 'es2022',
+    legacyOutput: false,
+    dts: false,
+    outDir: 'dist/browser',
+    clean: true,
+    platform: 'browser',
+    noExternal: ['brotli', 'buffer'],
+    treeshake: 'smallest',
+    external: ['undici'],
+    env: {
+      BROWSER: 'true',
+    },
   },
   {
     entryPoints: {


### PR DESCRIPTION
Current dynamic import of undici is for nodeJS usage only, but because of the dynamic import of `undici`, it fills up the logs with `node:http` warnings. They are harmless, but in some cases it fills up user's final build with an extra module containing undici's source. It is never imported, but our duty as library authors is to keep the build slim and non-problematic in every way.

![CleanShot 2024-08-19 at 13 08 23](https://github.com/user-attachments/assets/2d1c1022-c541-4522-8555-14b906e1fa4e)


Hence this PR splits up the build into browser build and regular build. Browser build will be used first and foremost by any bundlers(including Webpack 1+), the regular build with undici dynamic import will be used by NodeJS/bun/Deno/any non-browser environment. 

This allows us to remove `webpackIgnore`, simply because webpack will never encounter the dynamic import