### PR TITLE
fix: .on and .off types

### DIFF
--- a/.changeset/beige-paws-repair.md
+++ b/.changeset/beige-paws-repair.md
@@ -1,0 +1,5 @@
+---
+'@clockworklabs/spacetimedb-sdk': patch
+---
+
+types: Allow autocomplete in .on and .off types

--- a/packages/sdk/src/spacetimedb.ts
+++ b/packages/sdk/src/spacetimedb.ts
@@ -682,11 +682,17 @@ export class SpacetimeDBClient {
     this.#sendMessage(message);
   }
 
-  on(eventName: EventType | string, callback: (...args: any[]) => void): void {
+  on(
+    eventName: EventType | (string & {}),
+    callback: (...args: any[]) => void
+  ): void {
     this.emitter.on(eventName, callback);
   }
 
-  off(eventName: EventType | string, callback: (...args: any[]) => void): void {
+  off(
+    eventName: EventType | (string & {}),
+    callback: (...args: any[]) => void
+  ): void {
     this.emitter.off(eventName, callback);
   }
 


### PR DESCRIPTION
Closes #67

Allows autocomplete in .on and .off methods

![CleanShot 2024-08-21 at 17 09 24](https://github.com/user-attachments/assets/c89033d5-85fc-4825-82ab-f82f1abf27b1)
