### PR TITLE
Fix doc for SpacetimeDBClient constructor

### DIFF
--- a/packages/sdk/src/spacetimedb.ts
+++ b/packages/sdk/src/spacetimedb.ts
@@ -144,7 +144,7 @@ export class SpacetimeDBClient {
    * const name_or_address = "database_name"
    * const auth_token = undefined;
    *
-   * var spacetimeDBClient = new SpacetimeDBClient(host, name_or_address, auth_token, protocol);
+   * var spacetimeDBClient = new SpacetimeDBClient(host, name_or_address, auth_token);
    * ```
    */
   constructor(host: string, name_or_address: string, auth_token?: string) {


### PR DESCRIPTION
Remove `protocol` param as possible param for constructor

## Description of Changes

Remove `protocol` param as possible param for constructor

## API

- [ ] This is an API breaking change to the SDK

_If the API is breaking, please state below what will break_

## Requires SpacetimeDB PRs

_List any PRs here that are required for this SDK change to work_
