### PR TITLE
Update to v0.12.0

### DIFF
--- a/.changeset/spicy-walls-double.md
+++ b/.changeset/spicy-walls-double.md
@@ -1,0 +1,5 @@
+---
+'@clockworklabs/spacetimedb-sdk': patch
+---
+
+Updating to SpacetimeDB v0.12.0


### PR DESCRIPTION
This pull request includes a small change to the `.changeset/spicy-walls-double.md` file. The change updates the `@clockworklabs/spacetimedb-sdk` to version v0.12.0.

* [`.changeset/spicy-walls-double.md`](diffhunk://#diff-7f6ee819373514f9ade2aeb86f1023aa030ab66eed209a47cecedcf662139c36R1-R5): Updated `@clockworklabs/spacetimedb-sdk` to version v0.12.0.