### PR TITLE
fix: websocket message handling, Buffer, onConnect

### DIFF
--- a/.changeset/dull-mangos-appear.md
+++ b/.changeset/dull-mangos-appear.md
@@ -1,0 +1,5 @@
+---
+'@clockworklabs/spacetimedb-sdk': patch
+---
+
+fix: websocket message handling, Buffer, onConnect

--- a/packages/sdk/src/db_connection_impl.ts
+++ b/packages/sdk/src/db_connection_impl.ts
@@ -1,5 +1,5 @@
-import { Address } from './address.ts';
 import decompress from 'brotli/decompress';
+import { Address } from './address.ts';
 import {
   AlgebraicType,
   ProductType,
@@ -18,43 +18,41 @@ import BinaryReader from './binary_reader.ts';
 import BinaryWriter from './binary_writer.ts';
 import * as ws from './client_api/index.ts';
 import { ClientCache } from './client_cache.ts';
+import { DBConnectionBuilder } from './db_connection_builder.ts';
 import { SubscriptionBuilder, type DBContext } from './db_context.ts';
+import type { Event } from './event.ts';
 import { type EventContextInterface } from './event_context.ts';
 import { EventEmitter } from './event_emitter.ts';
 import type { Identity } from './identity.ts';
-import { stdbLogger } from './logger.ts';
 import type { IdentityTokenMessage, Message } from './message_types.ts';
 import type { ReducerEvent } from './reducer_event.ts';
 import type SpacetimeModule from './spacetime_module.ts';
 import { TableCache, type Operation, type TableUpdate } from './table_cache.ts';
-import { toPascalCase } from './utils.ts';
+import { deepEqual, toPascalCase } from './utils.ts';
 import { WebsocketDecompressAdapter } from './websocket_decompress_adapter.ts';
 import type { WebsocketTestAdapter } from './websocket_test_adapter.ts';
-import type { Event } from './event.ts';
-import { DBConnectionBuilder } from './db_connection_builder.ts';
-import { deepEqual } from './utils.ts';
+import { Buffer } from 'buffer';
 
 export {
   AlgebraicType,
   AlgebraicValue,
+  BinaryReader,
+  BinaryWriter,
+  DBConnectionBuilder,
+  deepEqual,
   ProductType,
   ProductTypeElement,
   ProductValue,
+  SubscriptionBuilder,
   SumType,
   SumTypeVariant,
+  TableCache,
+  type Event,
   type ReducerArgsAdapter,
   type ValueAdapter,
-  BinaryReader,
-  BinaryWriter,
-  TableCache,
-  DBConnectionBuilder,
-  SubscriptionBuilder,
-  type Event,
-  deepEqual,
 };
 
-export type { DBContext, EventContextInterface };
-export type { ReducerEvent };
+export type { DBContext, EventContextInterface, ReducerEvent };
 
 export type ConnectionEvent = 'connect' | 'disconnect' | 'connectError';
 
@@ -394,12 +392,7 @@ export class DBConnectionImpl<DBView = any, Reducers = any>
           this.token = message.token;
         }
         this.clientAddress = message.address;
-        this.#emitter.emit(
-          'connect',
-          this.token,
-          this.identity,
-          this.clientAddress
-        );
+        this.#emitter.emit('connect', this, this.identity, this.token);
       }
     });
   }

--- a/packages/sdk/src/db_connection_impl.ts
+++ b/packages/sdk/src/db_connection_impl.ts
@@ -148,7 +148,7 @@ export class DBConnectionImpl<DBView = any, Reducers = any>
       for (const update of rawTableUpdate.updates) {
         let decompressed: ws.QueryUpdate;
         if (update.tag === 'Brotli') {
-          const decompressedBuffer = decompress(new Buffer(update.value));
+          const decompressedBuffer = decompress(Buffer.from(update.value));
           decompressed = ws.QueryUpdate.deserialize(
             new BinaryReader(decompressedBuffer)
           );

--- a/packages/sdk/src/websocket_decompress_adapter.ts
+++ b/packages/sdk/src/websocket_decompress_adapter.ts
@@ -14,10 +14,10 @@ export class WebsocketDecompressAdapter {
     let decompressed: Uint8Array;
     switch (buffer[0]) {
       case 0:
-        decompressed = msg.data.slice(1);
+        decompressed = buffer.slice(1);
         break;
       case 1:
-        decompressed = decompress(new Buffer(buffer.slice(1)));
+        decompressed = decompress(Buffer.from(buffer.slice(1)));
         break;
       default:
         throw new Error('Invalid message type');

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -10,7 +10,11 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "spacetime:generate-bindings": "spacetime generate --lang typescript --out-dir src/module_bindings --project-path server",
+    "spacetime:start": "spacetime start server",
+    "spacetime:publish:local": "spacetime publish game --project-path server --server local",
+    "spacetime:publish": "spacetime publish game --project-path server --server testnet"
   },
   "workspaces": [
     "packages/*"

--- a/packages/test-app/server/src/lib.rs
+++ b/packages/test-app/server/src/lib.rs
@@ -1,6 +1,6 @@
 use spacetimedb::{reducer, table, Identity, ReducerContext, SpacetimeType, Table};
 
-#[table(name = player)]
+#[table(name = player, public)]
 pub struct Player {
     #[primary_key]
     owner_id: String,
@@ -14,7 +14,7 @@ pub struct Point {
     pub y: u16,
 }
 
-#[table(name = user)]
+#[table(name = user, public)]
 pub struct User {
     #[primary_key]
     pub identity: Identity,
@@ -23,5 +23,9 @@ pub struct User {
 
 #[reducer]
 pub fn create_player(ctx: &ReducerContext, name: String, location: Point) {
-    ctx.db.player().insert(Player { owner_id: ctx.sender.to_hex().to_string(), name, location });
+    ctx.db.player().insert(Player {
+        owner_id: ctx.sender.to_hex().to_string(),
+        name,
+        location,
+    });
 }

--- a/packages/test-app/src/App.tsx
+++ b/packages/test-app/src/App.tsx
@@ -1,38 +1,58 @@
 import { DBConnection } from './module_bindings';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import './App.css';
 import { Identity } from '@clockworklabs/spacetimedb-sdk';
 
 function App() {
-  const [connection] = useState<DBConnection>(
+  const [connection] = useState(() =>
     DBConnection.builder()
       .withUri('ws://localhost:3000')
-      .withModuleName('goldbreezycanid')
+      .withModuleName('game')
       .onDisconnect(() => {
         console.log('disconnected');
       })
       .onConnectError(() => {
         console.log('client_error');
       })
-      .onConnect((_, identity, _token) => {
+      .onConnect((conn, identity, _token) => {
         console.log(
           'Connected to SpacetimeDB with identity:',
           identity.toHexString()
         );
+
+        conn.subscriptionBuilder().subscribe(['SELECT * FROM player']);
       })
       .withCredentials([
         Identity.fromString(
-          '49f2d472cabfbc7ded52ac1f93316750dc8ea162aac97cc52a340aed221b7ff3'
+          '93dda09db9a56d8fa6c024d843e805d8262191db3b4ba84c5efcd1ad451fed4e'
         ),
-        'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJoZXhfaWRlbnRpdHkiOiI0OWYyZDQ3MmNhYmZiYzdkZWQ1MmFjMWY5MzMxNjc1MGRjOGVhMTYyYWFjOTdjYzUyYTM0MGFlZDIyMWI3ZmYzIiwiaWF0IjoxNjgwMTkwNDc5fQ.KPz0DjrWb6I5c51wa71FGTgWz0Nh6CiNycM0ynmDDNkGjRxsci5cmiEjHQdYKyIeaG9MizSVPGlaDJ2Z7uctcg',
+        'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJoZXhfaWRlbnRpdHkiOiI5M2RkYTA5ZGI5YTU2ZDhmYTZjMDI0ZDg0M2U4MDVkODI2MjE5MWRiM2I0YmE4NGM1ZWZjZDFhZDQ1MWZlZDRlIiwiaWF0IjoxNzI4MzY3NDk0LCJleHAiOm51bGx9.ua3DQaiXo5i3Ye0okughs84PV9uZLCnov26zvCMG-3ibqGg6vH0uDDY6L-zDf8XiFgUqEIcvnJvuKLThPDipjQ',
       ])
       .build()
   );
+
+  useEffect(() => {
+    connection.db.player.onInsert(player => {
+      console.log(player);
+    });
+
+    setTimeout(() => {
+      console.log(Array.from(connection.db.player.iter()));
+    }, 5000);
+  }, [connection]);
 
   return (
     <div className="App">
       <h1>Typescript SDK Test!</h1>
       <p>{connection.identity?.toHexString()}</p>
+
+      <button
+        onClick={() =>
+          connection.reducers.createPlayer('Hello', { x: 10, y: 40 })
+        }
+      >
+        Update
+      </button>
     </div>
   );
 }

--- a/packages/test-app/src/module_bindings/create_player_reducer.ts
+++ b/packages/test-app/src/module_bindings/create_player_reducer.ts
@@ -34,14 +34,16 @@ import {
   SumTypeVariant,
   // @ts-ignore
   TableCache,
-} from '@clockworklabs/spacetimedb-sdk';
+  // @ts-ignore
+  deepEqual,
+} from "@clockworklabs/spacetimedb-sdk";
 
 // @ts-ignore
-import { Point as __Point } from './point_type';
+import { Point as __Point } from "./point_type";
 
 export type CreatePlayer = {
-  name: string;
-  location: __Point;
+  name: string,
+  location: __Point,
 };
 
 /**
@@ -49,21 +51,23 @@ export type CreatePlayer = {
  */
 export namespace CreatePlayer {
   /**
-   * A function which returns this type represented as an AlgebraicType.
-   * This function is derived from the AlgebraicType used to generate this type.
-   */
-  export function getAlgebraicType(): AlgebraicType {
+  * A function which returns this type represented as an AlgebraicType.
+  * This function is derived from the AlgebraicType used to generate this type.
+  */
+  export function getTypeScriptAlgebraicType(): AlgebraicType {
     return AlgebraicType.createProductType([
-      new ProductTypeElement('name', AlgebraicType.createStringType()),
-      new ProductTypeElement('location', __Point.getAlgebraicType()),
+      new ProductTypeElement("name", AlgebraicType.createStringType()),
+      new ProductTypeElement("location", __Point.getTypeScriptAlgebraicType()),
     ]);
   }
 
   export function serialize(writer: BinaryWriter, value: CreatePlayer): void {
-    CreatePlayer.getAlgebraicType().serialize(writer, value);
+    CreatePlayer.getTypeScriptAlgebraicType().serialize(writer, value);
   }
 
   export function deserialize(reader: BinaryReader): CreatePlayer {
-    return CreatePlayer.getAlgebraicType().deserialize(reader);
+    return CreatePlayer.getTypeScriptAlgebraicType().deserialize(reader);
   }
+
 }
+

--- a/packages/test-app/src/module_bindings/create_player_reducer.ts
+++ b/packages/test-app/src/module_bindings/create_player_reducer.ts
@@ -36,14 +36,14 @@ import {
   TableCache,
   // @ts-ignore
   deepEqual,
-} from "@clockworklabs/spacetimedb-sdk";
+} from '@clockworklabs/spacetimedb-sdk';
 
 // @ts-ignore
-import { Point as __Point } from "./point_type";
+import { Point as __Point } from './point_type';
 
 export type CreatePlayer = {
-  name: string,
-  location: __Point,
+  name: string;
+  location: __Point;
 };
 
 /**
@@ -51,13 +51,13 @@ export type CreatePlayer = {
  */
 export namespace CreatePlayer {
   /**
-  * A function which returns this type represented as an AlgebraicType.
-  * This function is derived from the AlgebraicType used to generate this type.
-  */
+   * A function which returns this type represented as an AlgebraicType.
+   * This function is derived from the AlgebraicType used to generate this type.
+   */
   export function getTypeScriptAlgebraicType(): AlgebraicType {
     return AlgebraicType.createProductType([
-      new ProductTypeElement("name", AlgebraicType.createStringType()),
-      new ProductTypeElement("location", __Point.getTypeScriptAlgebraicType()),
+      new ProductTypeElement('name', AlgebraicType.createStringType()),
+      new ProductTypeElement('location', __Point.getTypeScriptAlgebraicType()),
     ]);
   }
 
@@ -68,6 +68,4 @@ export namespace CreatePlayer {
   export function deserialize(reader: BinaryReader): CreatePlayer {
     return CreatePlayer.getTypeScriptAlgebraicType().deserialize(reader);
   }
-
 }
-

--- a/packages/test-app/src/module_bindings/index.ts
+++ b/packages/test-app/src/module_bindings/index.ts
@@ -34,43 +34,45 @@ import {
   SumTypeVariant,
   // @ts-ignore
   TableCache,
-} from '@clockworklabs/spacetimedb-sdk';
+  // @ts-ignore
+  deepEqual,
+} from "@clockworklabs/spacetimedb-sdk";
 
 // Import and reexport all reducer arg types
-import { CreatePlayer } from './create_player_reducer.ts';
+import { CreatePlayer } from "./create_player_reducer.ts";
 export { CreatePlayer };
 
 // Import and reexport all table handle types
-import { PlayerTableHandle } from './player_table.ts';
+import { PlayerTableHandle } from "./player_table.ts";
 export { PlayerTableHandle };
-import { UserTableHandle } from './user_table.ts';
+import { UserTableHandle } from "./user_table.ts";
 export { UserTableHandle };
 
 // Import and reexport all types
-import { Player } from './player_type.ts';
+import { Player } from "./player_type.ts";
 export { Player };
-import { Point } from './point_type.ts';
+import { Point } from "./point_type.ts";
 export { Point };
-import { User } from './user_type.ts';
+import { User } from "./user_type.ts";
 export { User };
 
 const REMOTE_MODULE = {
   tables: {
     player: {
-      tableName: 'player',
-      rowType: Player.getAlgebraicType(),
-      primaryKey: 'owner_id',
+      tableName: "player",
+      rowType: Player.getTypeScriptAlgebraicType(),
+      primaryKey: "owner_id",
     },
     user: {
-      tableName: 'user',
-      rowType: User.getAlgebraicType(),
-      primaryKey: 'identity',
+      tableName: "user",
+      rowType: User.getTypeScriptAlgebraicType(),
+      primaryKey: "identity",
     },
   },
   reducers: {
     create_player: {
-      reducerName: 'create_player',
-      argsType: CreatePlayer.getAlgebraicType(),
+      reducerName: "create_player",
+      argsType: CreatePlayer.getTypeScriptAlgebraicType(),
     },
   },
   // Constructors which are used by the DBConnectionImpl to
@@ -78,19 +80,21 @@ const REMOTE_MODULE = {
   eventContextConstructor: (imp: DBConnectionImpl, event: Event<Reducer>) => {
     return {
       ...(imp as DBConnection),
-      event,
-    };
+      event
+    }
   },
   dbViewConstructor: (imp: DBConnectionImpl) => {
     return new RemoteTables(imp);
   },
   reducersConstructor: (imp: DBConnectionImpl) => {
     return new RemoteReducers(imp);
-  },
-};
+  }
+}
 
 // A type representing all the possible variants of a reducer.
-export type Reducer = never | { name: 'CreatePlayer'; args: CreatePlayer };
+export type Reducer = never
+| { name: "CreatePlayer", args: CreatePlayer }
+;
 
 export class RemoteReducers {
   constructor(private connection: DBConnectionImpl) {}
@@ -98,58 +102,37 @@ export class RemoteReducers {
   createPlayer(name: string, location: Point) {
     const __args = { name, location };
     let __writer = new BinaryWriter(1024);
-    CreatePlayer.getAlgebraicType().serialize(__writer, __args);
+    CreatePlayer.getTypeScriptAlgebraicType().serialize(__writer, __args);
     let __argsBuffer = __writer.getBuffer();
-    this.connection.callReducer('create_player', __argsBuffer);
+    this.connection.callReducer("create_player", __argsBuffer);
   }
 
-  onCreatePlayer(
-    callback: (ctx: EventContext, name: string, location: Point) => void
-  ) {
-    this.connection.onReducer('create_player', callback);
+  onCreatePlayer(callback: (ctx: EventContext, name: string, location: Point) => void) {
+    this.connection.onReducer("create_player", callback);
   }
 
-  removeOnCreatePlayer(
-    callback: (ctx: EventContext, name: string, location: Point) => void
-  ) {
-    this.connection.offReducer('create_player', callback);
+  removeOnCreatePlayer(callback: (ctx: EventContext, name: string, location: Point) => void) {
+    this.connection.offReducer("create_player", callback);
   }
+
 }
 
 export class RemoteTables {
   constructor(private connection: DBConnectionImpl) {}
 
   get player(): PlayerTableHandle {
-    return new PlayerTableHandle(
-      this.connection.clientCache.getOrCreateTable<Player>(
-        REMOTE_MODULE.tables.player
-      )
-    );
+    return new PlayerTableHandle(this.connection.clientCache.getOrCreateTable<Player>(REMOTE_MODULE.tables.player));
   }
 
   get user(): UserTableHandle {
-    return new UserTableHandle(
-      this.connection.clientCache.getOrCreateTable<User>(
-        REMOTE_MODULE.tables.user
-      )
-    );
+    return new UserTableHandle(this.connection.clientCache.getOrCreateTable<User>(REMOTE_MODULE.tables.user));
   }
 }
 
-export class DBConnection extends DBConnectionImpl<
-  RemoteTables,
-  RemoteReducers
-> {
-  static builder = (): DBConnectionBuilder<DBConnection> => {
-    return new DBConnectionBuilder<DBConnection>(
-      REMOTE_MODULE,
-      (imp: DBConnectionImpl) => imp as DBConnection
-    );
-  };
+export class DBConnection extends DBConnectionImpl<RemoteTables, RemoteReducers>  {
+  static builder = (): DBConnectionBuilder<DBConnection>  => {
+    return new DBConnectionBuilder<DBConnection>(REMOTE_MODULE, (imp: DBConnectionImpl) => imp as DBConnection);
+  }
 }
 
-export type EventContext = EventContextInterface<
-  RemoteTables,
-  RemoteReducers,
-  Reducer
->;
+export type EventContext = EventContextInterface<RemoteTables, RemoteReducers, Reducer>;

--- a/packages/test-app/src/module_bindings/index.ts
+++ b/packages/test-app/src/module_bindings/index.ts
@@ -36,42 +36,42 @@ import {
   TableCache,
   // @ts-ignore
   deepEqual,
-} from "@clockworklabs/spacetimedb-sdk";
+} from '@clockworklabs/spacetimedb-sdk';
 
 // Import and reexport all reducer arg types
-import { CreatePlayer } from "./create_player_reducer.ts";
+import { CreatePlayer } from './create_player_reducer.ts';
 export { CreatePlayer };
 
 // Import and reexport all table handle types
-import { PlayerTableHandle } from "./player_table.ts";
+import { PlayerTableHandle } from './player_table.ts';
 export { PlayerTableHandle };
-import { UserTableHandle } from "./user_table.ts";
+import { UserTableHandle } from './user_table.ts';
 export { UserTableHandle };
 
 // Import and reexport all types
-import { Player } from "./player_type.ts";
+import { Player } from './player_type.ts';
 export { Player };
-import { Point } from "./point_type.ts";
+import { Point } from './point_type.ts';
 export { Point };
-import { User } from "./user_type.ts";
+import { User } from './user_type.ts';
 export { User };
 
 const REMOTE_MODULE = {
   tables: {
     player: {
-      tableName: "player",
+      tableName: 'player',
       rowType: Player.getTypeScriptAlgebraicType(),
-      primaryKey: "owner_id",
+      primaryKey: 'owner_id',
     },
     user: {
-      tableName: "user",
+      tableName: 'user',
       rowType: User.getTypeScriptAlgebraicType(),
-      primaryKey: "identity",
+      primaryKey: 'identity',
     },
   },
   reducers: {
     create_player: {
-      reducerName: "create_player",
+      reducerName: 'create_player',
       argsType: CreatePlayer.getTypeScriptAlgebraicType(),
     },
   },
@@ -80,21 +80,19 @@ const REMOTE_MODULE = {
   eventContextConstructor: (imp: DBConnectionImpl, event: Event<Reducer>) => {
     return {
       ...(imp as DBConnection),
-      event
-    }
+      event,
+    };
   },
   dbViewConstructor: (imp: DBConnectionImpl) => {
     return new RemoteTables(imp);
   },
   reducersConstructor: (imp: DBConnectionImpl) => {
     return new RemoteReducers(imp);
-  }
-}
+  },
+};
 
 // A type representing all the possible variants of a reducer.
-export type Reducer = never
-| { name: "CreatePlayer", args: CreatePlayer }
-;
+export type Reducer = never | { name: 'CreatePlayer'; args: CreatePlayer };
 
 export class RemoteReducers {
   constructor(private connection: DBConnectionImpl) {}
@@ -104,35 +102,56 @@ export class RemoteReducers {
     let __writer = new BinaryWriter(1024);
     CreatePlayer.getTypeScriptAlgebraicType().serialize(__writer, __args);
     let __argsBuffer = __writer.getBuffer();
-    this.connection.callReducer("create_player", __argsBuffer);
+    this.connection.callReducer('create_player', __argsBuffer);
   }
 
-  onCreatePlayer(callback: (ctx: EventContext, name: string, location: Point) => void) {
-    this.connection.onReducer("create_player", callback);
+  onCreatePlayer(
+    callback: (ctx: EventContext, name: string, location: Point) => void
+  ) {
+    this.connection.onReducer('create_player', callback);
   }
 
-  removeOnCreatePlayer(callback: (ctx: EventContext, name: string, location: Point) => void) {
-    this.connection.offReducer("create_player", callback);
+  removeOnCreatePlayer(
+    callback: (ctx: EventContext, name: string, location: Point) => void
+  ) {
+    this.connection.offReducer('create_player', callback);
   }
-
 }
 
 export class RemoteTables {
   constructor(private connection: DBConnectionImpl) {}
 
   get player(): PlayerTableHandle {
-    return new PlayerTableHandle(this.connection.clientCache.getOrCreateTable<Player>(REMOTE_MODULE.tables.player));
+    return new PlayerTableHandle(
+      this.connection.clientCache.getOrCreateTable<Player>(
+        REMOTE_MODULE.tables.player
+      )
+    );
   }
 
   get user(): UserTableHandle {
-    return new UserTableHandle(this.connection.clientCache.getOrCreateTable<User>(REMOTE_MODULE.tables.user));
+    return new UserTableHandle(
+      this.connection.clientCache.getOrCreateTable<User>(
+        REMOTE_MODULE.tables.user
+      )
+    );
   }
 }
 
-export class DBConnection extends DBConnectionImpl<RemoteTables, RemoteReducers>  {
-  static builder = (): DBConnectionBuilder<DBConnection>  => {
-    return new DBConnectionBuilder<DBConnection>(REMOTE_MODULE, (imp: DBConnectionImpl) => imp as DBConnection);
-  }
+export class DBConnection extends DBConnectionImpl<
+  RemoteTables,
+  RemoteReducers
+> {
+  static builder = (): DBConnectionBuilder<DBConnection> => {
+    return new DBConnectionBuilder<DBConnection>(
+      REMOTE_MODULE,
+      (imp: DBConnectionImpl) => imp as DBConnection
+    );
+  };
 }
 
-export type EventContext = EventContextInterface<RemoteTables, RemoteReducers, Reducer>;
+export type EventContext = EventContextInterface<
+  RemoteTables,
+  RemoteReducers,
+  Reducer
+>;

--- a/packages/test-app/src/module_bindings/player_table.ts
+++ b/packages/test-app/src/module_bindings/player_table.ts
@@ -36,13 +36,13 @@ import {
   TableCache,
   // @ts-ignore
   deepEqual,
-} from "@clockworklabs/spacetimedb-sdk";
-import { Player } from "./player_type";
+} from '@clockworklabs/spacetimedb-sdk';
+import { Player } from './player_type';
 // @ts-ignore
-import { Point as __Point } from "./point_type";
+import { Point as __Point } from './point_type';
 
 // @ts-ignore
-import { EventContext, Reducer, RemoteReducers, RemoteTables } from ".";
+import { EventContext, Reducer, RemoteReducers, RemoteTables } from '.';
 
 /**
  * Table handle for the table `player`.
@@ -93,25 +93,30 @@ export class PlayerTableHandle {
 
   onInsert = (cb: (ctx: EventContext, row: Player) => void) => {
     return this.tableCache.onInsert(cb);
-  }
+  };
 
   removeOnInsert = (cb: (ctx: EventContext, row: Player) => void) => {
     return this.tableCache.removeOnInsert(cb);
-  }
+  };
 
   onDelete = (cb: (ctx: EventContext, row: Player) => void) => {
     return this.tableCache.onDelete(cb);
-  }
+  };
 
   removeOnDelete = (cb: (ctx: EventContext, row: Player) => void) => {
     return this.tableCache.removeOnDelete(cb);
-  }
+  };
 
   // Updates are only defined for tables with primary keys.
-  onUpdate = (cb: (ctx: EventContext, oldRow: Player, newRow: Player) => void) => {
+  onUpdate = (
+    cb: (ctx: EventContext, oldRow: Player, newRow: Player) => void
+  ) => {
     return this.tableCache.onUpdate(cb);
-  }
+  };
 
-  removeOnUpdate = (cb: (ctx: EventContext, onRow: Player, newRow: Player) => void) => {
+  removeOnUpdate = (
+    cb: (ctx: EventContext, onRow: Player, newRow: Player) => void
+  ) => {
     return this.tableCache.removeOnUpdate(cb);
-  }}
+  };
+}

--- a/packages/test-app/src/module_bindings/player_table.ts
+++ b/packages/test-app/src/module_bindings/player_table.ts
@@ -3,8 +3,6 @@
 
 import {
   // @ts-ignore
-  deepEqual,
-  // @ts-ignore
   Address,
   // @ts-ignore
   AlgebraicType,
@@ -36,13 +34,15 @@ import {
   SumTypeVariant,
   // @ts-ignore
   TableCache,
-} from '@clockworklabs/spacetimedb-sdk';
-import { Player } from './player_type';
+  // @ts-ignore
+  deepEqual,
+} from "@clockworklabs/spacetimedb-sdk";
+import { Player } from "./player_type";
 // @ts-ignore
-import { Point as __Point } from './point_type';
+import { Point as __Point } from "./point_type";
 
 // @ts-ignore
-import { EventContext, Reducer, RemoteReducers, RemoteTables } from '.';
+import { EventContext, Reducer, RemoteReducers, RemoteTables } from ".";
 
 /**
  * Table handle for the table `player`.
@@ -93,30 +93,25 @@ export class PlayerTableHandle {
 
   onInsert = (cb: (ctx: EventContext, row: Player) => void) => {
     return this.tableCache.onInsert(cb);
-  };
+  }
 
   removeOnInsert = (cb: (ctx: EventContext, row: Player) => void) => {
     return this.tableCache.removeOnInsert(cb);
-  };
+  }
 
   onDelete = (cb: (ctx: EventContext, row: Player) => void) => {
     return this.tableCache.onDelete(cb);
-  };
+  }
 
   removeOnDelete = (cb: (ctx: EventContext, row: Player) => void) => {
     return this.tableCache.removeOnDelete(cb);
-  };
+  }
 
   // Updates are only defined for tables with primary keys.
-  onUpdate = (
-    cb: (ctx: EventContext, oldRow: Player, newRow: Player) => void
-  ) => {
+  onUpdate = (cb: (ctx: EventContext, oldRow: Player, newRow: Player) => void) => {
     return this.tableCache.onUpdate(cb);
-  };
+  }
 
-  removeOnUpdate = (
-    cb: (ctx: EventContext, onRow: Player, newRow: Player) => void
-  ) => {
+  removeOnUpdate = (cb: (ctx: EventContext, onRow: Player, newRow: Player) => void) => {
     return this.tableCache.removeOnUpdate(cb);
-  };
-}
+  }}

--- a/packages/test-app/src/module_bindings/player_type.ts
+++ b/packages/test-app/src/module_bindings/player_type.ts
@@ -36,14 +36,14 @@ import {
   TableCache,
   // @ts-ignore
   deepEqual,
-} from "@clockworklabs/spacetimedb-sdk";
+} from '@clockworklabs/spacetimedb-sdk';
 // @ts-ignore
-import { Point as __Point } from "./point_type";
+import { Point as __Point } from './point_type';
 
 export type Player = {
-  ownerId: string,
-  name: string,
-  location: __Point,
+  ownerId: string;
+  name: string;
+  location: __Point;
 };
 
 /**
@@ -51,14 +51,14 @@ export type Player = {
  */
 export namespace Player {
   /**
-  * A function which returns this type represented as an AlgebraicType.
-  * This function is derived from the AlgebraicType used to generate this type.
-  */
+   * A function which returns this type represented as an AlgebraicType.
+   * This function is derived from the AlgebraicType used to generate this type.
+   */
   export function getTypeScriptAlgebraicType(): AlgebraicType {
     return AlgebraicType.createProductType([
-      new ProductTypeElement("ownerId", AlgebraicType.createStringType()),
-      new ProductTypeElement("name", AlgebraicType.createStringType()),
-      new ProductTypeElement("location", __Point.getTypeScriptAlgebraicType()),
+      new ProductTypeElement('ownerId', AlgebraicType.createStringType()),
+      new ProductTypeElement('name', AlgebraicType.createStringType()),
+      new ProductTypeElement('location', __Point.getTypeScriptAlgebraicType()),
     ]);
   }
 
@@ -69,7 +69,4 @@ export namespace Player {
   export function deserialize(reader: BinaryReader): Player {
     return Player.getTypeScriptAlgebraicType().deserialize(reader);
   }
-
 }
-
-

--- a/packages/test-app/src/module_bindings/player_type.ts
+++ b/packages/test-app/src/module_bindings/player_type.ts
@@ -34,14 +34,16 @@ import {
   SumTypeVariant,
   // @ts-ignore
   TableCache,
-} from '@clockworklabs/spacetimedb-sdk';
+  // @ts-ignore
+  deepEqual,
+} from "@clockworklabs/spacetimedb-sdk";
 // @ts-ignore
-import { Point as __Point } from './point_type';
+import { Point as __Point } from "./point_type";
 
 export type Player = {
-  ownerId: string;
-  name: string;
-  location: __Point;
+  ownerId: string,
+  name: string,
+  location: __Point,
 };
 
 /**
@@ -49,22 +51,25 @@ export type Player = {
  */
 export namespace Player {
   /**
-   * A function which returns this type represented as an AlgebraicType.
-   * This function is derived from the AlgebraicType used to generate this type.
-   */
-  export function getAlgebraicType(): AlgebraicType {
+  * A function which returns this type represented as an AlgebraicType.
+  * This function is derived from the AlgebraicType used to generate this type.
+  */
+  export function getTypeScriptAlgebraicType(): AlgebraicType {
     return AlgebraicType.createProductType([
-      new ProductTypeElement('ownerId', AlgebraicType.createStringType()),
-      new ProductTypeElement('name', AlgebraicType.createStringType()),
-      new ProductTypeElement('location', __Point.getAlgebraicType()),
+      new ProductTypeElement("ownerId", AlgebraicType.createStringType()),
+      new ProductTypeElement("name", AlgebraicType.createStringType()),
+      new ProductTypeElement("location", __Point.getTypeScriptAlgebraicType()),
     ]);
   }
 
   export function serialize(writer: BinaryWriter, value: Player): void {
-    Player.getAlgebraicType().serialize(writer, value);
+    Player.getTypeScriptAlgebraicType().serialize(writer, value);
   }
 
   export function deserialize(reader: BinaryReader): Player {
-    return Player.getAlgebraicType().deserialize(reader);
+    return Player.getTypeScriptAlgebraicType().deserialize(reader);
   }
+
 }
+
+

--- a/packages/test-app/src/module_bindings/point_type.ts
+++ b/packages/test-app/src/module_bindings/point_type.ts
@@ -36,10 +36,10 @@ import {
   TableCache,
   // @ts-ignore
   deepEqual,
-} from "@clockworklabs/spacetimedb-sdk";
+} from '@clockworklabs/spacetimedb-sdk';
 export type Point = {
-  x: number,
-  y: number,
+  x: number;
+  y: number;
 };
 
 /**
@@ -47,13 +47,13 @@ export type Point = {
  */
 export namespace Point {
   /**
-  * A function which returns this type represented as an AlgebraicType.
-  * This function is derived from the AlgebraicType used to generate this type.
-  */
+   * A function which returns this type represented as an AlgebraicType.
+   * This function is derived from the AlgebraicType used to generate this type.
+   */
   export function getTypeScriptAlgebraicType(): AlgebraicType {
     return AlgebraicType.createProductType([
-      new ProductTypeElement("x", AlgebraicType.createU16Type()),
-      new ProductTypeElement("y", AlgebraicType.createU16Type()),
+      new ProductTypeElement('x', AlgebraicType.createU16Type()),
+      new ProductTypeElement('y', AlgebraicType.createU16Type()),
     ]);
   }
 
@@ -64,7 +64,4 @@ export namespace Point {
   export function deserialize(reader: BinaryReader): Point {
     return Point.getTypeScriptAlgebraicType().deserialize(reader);
   }
-
 }
-
-

--- a/packages/test-app/src/module_bindings/point_type.ts
+++ b/packages/test-app/src/module_bindings/point_type.ts
@@ -34,10 +34,12 @@ import {
   SumTypeVariant,
   // @ts-ignore
   TableCache,
-} from '@clockworklabs/spacetimedb-sdk';
+  // @ts-ignore
+  deepEqual,
+} from "@clockworklabs/spacetimedb-sdk";
 export type Point = {
-  x: number;
-  y: number;
+  x: number,
+  y: number,
 };
 
 /**
@@ -45,21 +47,24 @@ export type Point = {
  */
 export namespace Point {
   /**
-   * A function which returns this type represented as an AlgebraicType.
-   * This function is derived from the AlgebraicType used to generate this type.
-   */
-  export function getAlgebraicType(): AlgebraicType {
+  * A function which returns this type represented as an AlgebraicType.
+  * This function is derived from the AlgebraicType used to generate this type.
+  */
+  export function getTypeScriptAlgebraicType(): AlgebraicType {
     return AlgebraicType.createProductType([
-      new ProductTypeElement('x', AlgebraicType.createU16Type()),
-      new ProductTypeElement('y', AlgebraicType.createU16Type()),
+      new ProductTypeElement("x", AlgebraicType.createU16Type()),
+      new ProductTypeElement("y", AlgebraicType.createU16Type()),
     ]);
   }
 
   export function serialize(writer: BinaryWriter, value: Point): void {
-    Point.getAlgebraicType().serialize(writer, value);
+    Point.getTypeScriptAlgebraicType().serialize(writer, value);
   }
 
   export function deserialize(reader: BinaryReader): Point {
-    return Point.getAlgebraicType().deserialize(reader);
+    return Point.getTypeScriptAlgebraicType().deserialize(reader);
   }
+
 }
+
+

--- a/packages/test-app/src/module_bindings/user_table.ts
+++ b/packages/test-app/src/module_bindings/user_table.ts
@@ -36,10 +36,10 @@ import {
   TableCache,
   // @ts-ignore
   deepEqual,
-} from "@clockworklabs/spacetimedb-sdk";
-import { User } from "./user_type";
+} from '@clockworklabs/spacetimedb-sdk';
+import { User } from './user_type';
 // @ts-ignore
-import { EventContext, Reducer, RemoteReducers, RemoteTables } from ".";
+import { EventContext, Reducer, RemoteReducers, RemoteTables } from '.';
 
 /**
  * Table handle for the table `user`.
@@ -90,25 +90,28 @@ export class UserTableHandle {
 
   onInsert = (cb: (ctx: EventContext, row: User) => void) => {
     return this.tableCache.onInsert(cb);
-  }
+  };
 
   removeOnInsert = (cb: (ctx: EventContext, row: User) => void) => {
     return this.tableCache.removeOnInsert(cb);
-  }
+  };
 
   onDelete = (cb: (ctx: EventContext, row: User) => void) => {
     return this.tableCache.onDelete(cb);
-  }
+  };
 
   removeOnDelete = (cb: (ctx: EventContext, row: User) => void) => {
     return this.tableCache.removeOnDelete(cb);
-  }
+  };
 
   // Updates are only defined for tables with primary keys.
   onUpdate = (cb: (ctx: EventContext, oldRow: User, newRow: User) => void) => {
     return this.tableCache.onUpdate(cb);
-  }
+  };
 
-  removeOnUpdate = (cb: (ctx: EventContext, onRow: User, newRow: User) => void) => {
+  removeOnUpdate = (
+    cb: (ctx: EventContext, onRow: User, newRow: User) => void
+  ) => {
     return this.tableCache.removeOnUpdate(cb);
-  }}
+  };
+}

--- a/packages/test-app/src/module_bindings/user_table.ts
+++ b/packages/test-app/src/module_bindings/user_table.ts
@@ -3,8 +3,6 @@
 
 import {
   // @ts-ignore
-  deepEqual,
-  // @ts-ignore
   Address,
   // @ts-ignore
   AlgebraicType,
@@ -36,10 +34,12 @@ import {
   SumTypeVariant,
   // @ts-ignore
   TableCache,
-} from '@clockworklabs/spacetimedb-sdk';
-import { User } from './user_type';
+  // @ts-ignore
+  deepEqual,
+} from "@clockworklabs/spacetimedb-sdk";
+import { User } from "./user_type";
 // @ts-ignore
-import { EventContext, Reducer, RemoteReducers, RemoteTables } from '.';
+import { EventContext, Reducer, RemoteReducers, RemoteTables } from ".";
 
 /**
  * Table handle for the table `user`.
@@ -90,28 +90,25 @@ export class UserTableHandle {
 
   onInsert = (cb: (ctx: EventContext, row: User) => void) => {
     return this.tableCache.onInsert(cb);
-  };
+  }
 
   removeOnInsert = (cb: (ctx: EventContext, row: User) => void) => {
     return this.tableCache.removeOnInsert(cb);
-  };
+  }
 
   onDelete = (cb: (ctx: EventContext, row: User) => void) => {
     return this.tableCache.onDelete(cb);
-  };
+  }
 
   removeOnDelete = (cb: (ctx: EventContext, row: User) => void) => {
     return this.tableCache.removeOnDelete(cb);
-  };
+  }
 
   // Updates are only defined for tables with primary keys.
   onUpdate = (cb: (ctx: EventContext, oldRow: User, newRow: User) => void) => {
     return this.tableCache.onUpdate(cb);
-  };
+  }
 
-  removeOnUpdate = (
-    cb: (ctx: EventContext, onRow: User, newRow: User) => void
-  ) => {
+  removeOnUpdate = (cb: (ctx: EventContext, onRow: User, newRow: User) => void) => {
     return this.tableCache.removeOnUpdate(cb);
-  };
-}
+  }}

--- a/packages/test-app/src/module_bindings/user_type.ts
+++ b/packages/test-app/src/module_bindings/user_type.ts
@@ -34,10 +34,12 @@ import {
   SumTypeVariant,
   // @ts-ignore
   TableCache,
-} from '@clockworklabs/spacetimedb-sdk';
+  // @ts-ignore
+  deepEqual,
+} from "@clockworklabs/spacetimedb-sdk";
 export type User = {
-  identity: Identity;
-  username: string;
+  identity: Identity,
+  username: string,
 };
 
 /**
@@ -45,21 +47,24 @@ export type User = {
  */
 export namespace User {
   /**
-   * A function which returns this type represented as an AlgebraicType.
-   * This function is derived from the AlgebraicType used to generate this type.
-   */
-  export function getAlgebraicType(): AlgebraicType {
+  * A function which returns this type represented as an AlgebraicType.
+  * This function is derived from the AlgebraicType used to generate this type.
+  */
+  export function getTypeScriptAlgebraicType(): AlgebraicType {
     return AlgebraicType.createProductType([
-      new ProductTypeElement('identity', AlgebraicType.createIdentityType()),
-      new ProductTypeElement('username', AlgebraicType.createStringType()),
+      new ProductTypeElement("identity", AlgebraicType.createIdentityType()),
+      new ProductTypeElement("username", AlgebraicType.createStringType()),
     ]);
   }
 
   export function serialize(writer: BinaryWriter, value: User): void {
-    User.getAlgebraicType().serialize(writer, value);
+    User.getTypeScriptAlgebraicType().serialize(writer, value);
   }
 
   export function deserialize(reader: BinaryReader): User {
-    return User.getAlgebraicType().deserialize(reader);
+    return User.getTypeScriptAlgebraicType().deserialize(reader);
   }
+
 }
+
+

--- a/packages/test-app/src/module_bindings/user_type.ts
+++ b/packages/test-app/src/module_bindings/user_type.ts
@@ -36,10 +36,10 @@ import {
   TableCache,
   // @ts-ignore
   deepEqual,
-} from "@clockworklabs/spacetimedb-sdk";
+} from '@clockworklabs/spacetimedb-sdk';
 export type User = {
-  identity: Identity,
-  username: string,
+  identity: Identity;
+  username: string;
 };
 
 /**
@@ -47,13 +47,13 @@ export type User = {
  */
 export namespace User {
   /**
-  * A function which returns this type represented as an AlgebraicType.
-  * This function is derived from the AlgebraicType used to generate this type.
-  */
+   * A function which returns this type represented as an AlgebraicType.
+   * This function is derived from the AlgebraicType used to generate this type.
+   */
   export function getTypeScriptAlgebraicType(): AlgebraicType {
     return AlgebraicType.createProductType([
-      new ProductTypeElement("identity", AlgebraicType.createIdentityType()),
-      new ProductTypeElement("username", AlgebraicType.createStringType()),
+      new ProductTypeElement('identity', AlgebraicType.createIdentityType()),
+      new ProductTypeElement('username', AlgebraicType.createStringType()),
     ]);
   }
 
@@ -64,7 +64,4 @@ export namespace User {
   export function deserialize(reader: BinaryReader): User {
     return User.getTypeScriptAlgebraicType().deserialize(reader);
   }
-
 }
-
-


### PR DESCRIPTION
Fixes a few trivial things
- WebSocket message handling was returning the wrong ArrayBuffer
- db_connection_impl wasn't importing Buffer causing errors in browser
- onConnect was providing wrong arguments, fixes that
- test-app lib.rs now uses public tables

Rest of changes are codegen