### PR TITLE
Bump version to RC3

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -2,7 +2,7 @@
 
 ### Overview
 
-> NOTE: This SDK is currently in Release Candidate stage and tied to SpacetimeDB `v1.0.0-rc1`. Expect breaking changes in the future.
+> NOTE: This SDK is currently in Release Candidate stage and tied to SpacetimeDB `v1.0.0-rc3`. Expect breaking changes in the future.
 
 This repository contains the TypeScript SDK for SpacetimeDB. The SDK allows to interact with the database server and is prepared to work with code generated from a SpacetimeDB backend code.
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clockworklabs/spacetimedb-sdk",
-  "version": "1.0.0-rc1.0",
+  "version": "1.0.0-rc3.0",
   "description": "SDK for SpacetimeDB",
   "author": {
     "name": "Clockwork Labs",

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@clockworklabs/test-app",
   "private": true,
-  "version": "0.0.3-rc1.0",
+  "version": "1.0.0-rc3.0",
   "type": "module",
   "files": [
     "src"


### PR DESCRIPTION
## Description of Changes

Bumps version numbers to RC3. I'm not confident that I haven't missed any.

## API

Not breaking.

## Requires SpacetimeDB PRs

https://github.com/clockworklabs/SpacetimeDB/pull/2094