### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -2,8 +2,6 @@
 
 ### Overview
 
-> NOTE: This SDK is currently in Release Candidate stage and tied to SpacetimeDB `v1.0.0-rc1`. Expect breaking changes in the future.
-
 This repository contains the TypeScript SDK for SpacetimeDB. The SDK allows to interact with the database server and is prepared to work with code generated from a SpacetimeDB backend code.
 
 ### Installation

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clockworklabs/spacetimedb-sdk",
-  "version": "1.0.0-rc1.0",
+  "version": "1.0.0",
   "description": "SDK for SpacetimeDB",
   "author": {
     "name": "Clockwork Labs",

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@clockworklabs/test-app",
   "private": true,
-  "version": "0.0.3-rc1.0",
+  "version": "0.0.0",
   "type": "module",
   "files": [
     "src"


### PR DESCRIPTION
## Description of Changes

Bumps version numbers to 1.0.0. I'm not confident that I haven't missed any.

It's not obvious to me that this is the "correct" way to update these versions, since I'm unfamiliar with the changeset docs.

## API

Not breaking.

## Requires SpacetimeDB PRs

https://github.com/clockworklabs/SpacetimeDB/pull/2283