### PR TITLE
Amend `withCredentials` to `withToken`

### DIFF
--- a/examples/quickstart/src/App.tsx
+++ b/examples/quickstart/src/App.tsx
@@ -36,7 +36,7 @@ function App() {
         conn.current = await DbConnection.builder()
           .withUri('ws://localhost:3000')
           .withModuleName('chat')
-          .withCredentials([Identity.fromString(identity!), token!])
+          .withToken(token)
           .onDisconnect(() => {
             console.log('disconnected');
           })

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -42,7 +42,7 @@ const connection = DBConnection.builder()
 
     connection.subscriptionBuilder().subscribe(['SELECT * FROM player']);
   })
-  .withCredentials([Identity.fromString('IDENTITY'), 'TOKEN'])
+  .withToken('TOKEN')
   .build();
 ```
 

--- a/packages/sdk/src/db_connection_builder.ts
+++ b/packages/sdk/src/db_connection_builder.ts
@@ -52,11 +52,9 @@ export class DBConnectionBuilder<DBConnection> {
     return this;
   }
 
-  withCredentials(
-    creds: [identity: Identity, token: string]
+  withToken(
+    token: string?
   ): DBConnectionBuilder<DBConnection> {
-    const [identity, token] = creds;
-    this.#identity = identity;
     this.#token = token;
     return this;
   }

--- a/packages/sdk/src/db_connection_builder.ts
+++ b/packages/sdk/src/db_connection_builder.ts
@@ -52,9 +52,7 @@ export class DBConnectionBuilder<DBConnection> {
     return this;
   }
 
-  withToken(
-    token?: string
-  ): DBConnectionBuilder<DBConnection> {
+  withToken(token?: string): DBConnectionBuilder<DBConnection> {
     this.#token = token;
     return this;
   }

--- a/packages/sdk/src/db_connection_builder.ts
+++ b/packages/sdk/src/db_connection_builder.ts
@@ -53,7 +53,7 @@ export class DBConnectionBuilder<DBConnection> {
   }
 
   withToken(
-    token: string?
+    token?: string
   ): DBConnectionBuilder<DBConnection> {
     this.#token = token;
     return this;

--- a/packages/test-app/src/App.tsx
+++ b/packages/test-app/src/App.tsx
@@ -23,12 +23,9 @@ function App() {
 
         conn.subscriptionBuilder().subscribe(['SELECT * FROM player']);
       })
-      .withCredentials([
-        Identity.fromString(
-          'c200b22f7f282b8e44b908a9b020eabb2a7e554dd225461346603ab79255cffa'
-        ),
+      .withToken(
         'eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIwMUpCQTBYRzRESFpIWUdQQk5GRFk5RDQ2SiIsImlzcyI6Imh0dHBzOi8vYXV0aC5zdGFnaW5nLnNwYWNldGltZWRiLmNvbSIsImlhdCI6MTczMDgwODUwNSwiZXhwIjoxNzkzODgwNTA1fQ.kGM4HGX0c0twL8NJoSQowzSZa8dc2Ogc-fsvaDK7otUrcdGFsZ3KsNON2eNkFh73FER0hl55_eJStr2tgoPwfTyl_v_TqkY45iUOUlLmHfB-X42cMzpE7PXbR_PKYcp-P-Wa4jGtVl4oF7CvdGKxlhIYEk3e0ElQlA9ThnZN4IEciYV0vwAXGqbaO9SOG8jbrmlmfN7oKgl02EgpodEAHTrnB2mD1qf1YyOw7_9n_EkxJxWLkJf9-nFCVRrbfSLqSJBeE6OKNAu2VLLYrSFE7GkVXNCFVugoCDM2oVJogX75AgzWimrp75QRmLsXbvB-YvvRkQ8Gfb2RZnqCj9kiYg',
-      ])
+      )
       .build()
   );
 

--- a/packages/test-app/src/App.tsx
+++ b/packages/test-app/src/App.tsx
@@ -24,7 +24,7 @@ function App() {
         conn.subscriptionBuilder().subscribe(['SELECT * FROM player']);
       })
       .withToken(
-        'eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIwMUpCQTBYRzRESFpIWUdQQk5GRFk5RDQ2SiIsImlzcyI6Imh0dHBzOi8vYXV0aC5zdGFnaW5nLnNwYWNldGltZWRiLmNvbSIsImlhdCI6MTczMDgwODUwNSwiZXhwIjoxNzkzODgwNTA1fQ.kGM4HGX0c0twL8NJoSQowzSZa8dc2Ogc-fsvaDK7otUrcdGFsZ3KsNON2eNkFh73FER0hl55_eJStr2tgoPwfTyl_v_TqkY45iUOUlLmHfB-X42cMzpE7PXbR_PKYcp-P-Wa4jGtVl4oF7CvdGKxlhIYEk3e0ElQlA9ThnZN4IEciYV0vwAXGqbaO9SOG8jbrmlmfN7oKgl02EgpodEAHTrnB2mD1qf1YyOw7_9n_EkxJxWLkJf9-nFCVRrbfSLqSJBeE6OKNAu2VLLYrSFE7GkVXNCFVugoCDM2oVJogX75AgzWimrp75QRmLsXbvB-YvvRkQ8Gfb2RZnqCj9kiYg',
+        'eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIwMUpCQTBYRzRESFpIWUdQQk5GRFk5RDQ2SiIsImlzcyI6Imh0dHBzOi8vYXV0aC5zdGFnaW5nLnNwYWNldGltZWRiLmNvbSIsImlhdCI6MTczMDgwODUwNSwiZXhwIjoxNzkzODgwNTA1fQ.kGM4HGX0c0twL8NJoSQowzSZa8dc2Ogc-fsvaDK7otUrcdGFsZ3KsNON2eNkFh73FER0hl55_eJStr2tgoPwfTyl_v_TqkY45iUOUlLmHfB-X42cMzpE7PXbR_PKYcp-P-Wa4jGtVl4oF7CvdGKxlhIYEk3e0ElQlA9ThnZN4IEciYV0vwAXGqbaO9SOG8jbrmlmfN7oKgl02EgpodEAHTrnB2mD1qf1YyOw7_9n_EkxJxWLkJf9-nFCVRrbfSLqSJBeE6OKNAu2VLLYrSFE7GkVXNCFVugoCDM2oVJogX75AgzWimrp75QRmLsXbvB-YvvRkQ8Gfb2RZnqCj9kiYg'
       )
       .build()
   );


### PR DESCRIPTION
## Description of Changes

`withCredentials` was designed for our old auth model, where tokens were always issued by the SpacetimeDB host alongside an `Identity`, and therefore the bearer always knew their `Identity`.

In our new auth model,
a client may have a valid auth-able JWT but not know what `Identity` it will result in, as the `Identity` is computed based on the hash of some of the token's contents, and this hashing algorithm is not included in our client SDKs. As such, this PR revises `withCredentials` to `withToken`, which just accepts the token.

## API

- [x] This is an API breaking change to the SDK

See description.

## Requires SpacetimeDB PRs

N/a

## Testing

Completely untested.
