### PR TITLE
Switch to Bearer auth

### DIFF
--- a/packages/sdk/src/websocket_decompress_adapter.ts
+++ b/packages/sdk/src/websocket_decompress_adapter.ts
@@ -76,7 +76,7 @@ export class WebsocketDecompressAdapter {
   }): Promise<WebsocketDecompressAdapter> {
     const headers = new Headers();
     if (authToken) {
-      headers.set('Authorization', `Basic ${btoa('token:' + authToken)}`);
+      headers.set('Authorization', `Bearer ${authToken}`);
     }
 
     let WS: typeof WebSocket;


### PR DESCRIPTION
## Description of Changes

Switches to Bearer authentication, which is the more proper auth schema to use with tokens.

## API

- [ ] This is an API breaking change to the SDK

## Requires SpacetimeDB PRs

- https://github.com/clockworklabs/SpacetimeDB/pull/2181
