### PR TITLE
Import timestamp and duration by file, not from root

### DIFF
--- a/packages/sdk/src/algebraic_type.ts
+++ b/packages/sdk/src/algebraic_type.ts
@@ -1,4 +1,5 @@
-import { TimeDuration, Timestamp } from '.';
+import { TimeDuration } from './time_duration';
+import { Timestamp } from './timestamp';
 import { ConnectionId } from './connection_id';
 import type BinaryReader from './binary_reader';
 import type BinaryWriter from './binary_writer';


### PR DESCRIPTION
## Description of Changes

This fixes a circular import or circular definition problem that we don't fully understand.

## API

- [ ] This is an API breaking change to the SDK

_If the API is breaking, please state below what will break_

## Requires SpacetimeDB PRs

_List any PRs here that are required for this SDK change to work_

## Testing

_Write instructions for a test that you performed for this PR_

- [x] Changes  `pnpm run test` errors locally.