### PR TITLE
Bump version for release

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clockworklabs/spacetimedb-sdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "SDK for SpacetimeDB",
   "author": {
     "name": "Clockwork Labs",


### PR DESCRIPTION
## Description of Changes

We're *pretty* sure that this will ship out the 1.0.0 release. Our last release was accidentally shipped out as 1.0.0 so this release is 1.0.1 which is compatible with 1.0.0!

## API

- [x] This is an API breaking change to the SDK

This contains a lot of breaking changes from the previous release but this is known.

## Requires SpacetimeDB PRs

Requires tag `v1.0.0`

## Testing

- [x] I ran the quickstart client against this version and it worked!
