### PR TITLE
Set other url params even if we dont have an authToken.

### DIFF
--- a/packages/sdk/src/websocket_decompress_adapter.ts
+++ b/packages/sdk/src/websocket_decompress_adapter.ts
@@ -97,14 +97,14 @@ export class WebsocketDecompressAdapter {
       if (response.ok) {
         const { token } = await response.json();
         url.searchParams.set('token', token);
-        url.searchParams.set(
-          'compression',
-          compression === 'gzip' ? 'Gzip' : 'None'
-        );
-        if (lightMode) {
-          url.searchParams.set('light', 'true');
-        }
       }
+    }
+    url.searchParams.set(
+      'compression',
+      compression === 'gzip' ? 'Gzip' : 'None'
+    );
+    if (lightMode) {
+      url.searchParams.set('light', 'true');
     }
 
     const ws = new WS(url, wsProtocol);


### PR DESCRIPTION
## Description of Changes

This fixes a bug that made parsing large messages fail if the connection was created without an existing auth token.

## Testing

I tested manually using a version of the quickstart that sends very large messages and ignores the auth token in local storage.