### PR TITLE
Release 1.1.0

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clockworklabs/spacetimedb-sdk",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "SDK for SpacetimeDB",
   "author": {
     "name": "Clockwork Labs",


### PR DESCRIPTION
## Description of Changes

There are no new PRs since the last release, but we still need to bump the minor version.

**Merging this PR will cause a new package version to be published**

## API

- [ ] This is an API breaking change to the SDK

No breaking changes

## Requires SpacetimeDB PRs

https://github.com/clockworklabs/SpacetimeDB/pull/2566

## Testing

This just bumps the version. No new changes have merged since 1.0.3, so no new testing required.