### PR TITLE
Subscribe to all the subscriptions together in the quickstart example.

### DIFF
--- a/examples/quickstart-chat/src/App.tsx
+++ b/examples/quickstart-chat/src/App.tsx
@@ -92,14 +92,12 @@ function App() {
 
   useEffect(() => {
     const subscribeToQueries = (conn: DbConnection, queries: string[]) => {
-      for (const query of queries) {
-        conn
-          ?.subscriptionBuilder()
-          .onApplied(() => {
-            console.log('SDK client cache initialized.');
-          })
-          .subscribe(query);
-      }
+      conn
+        ?.subscriptionBuilder()
+        .onApplied(() => {
+          console.log('SDK client cache initialized.');
+        })
+        .subscribe(queries);
     };
 
     const onConnect = (


### PR DESCRIPTION
## Description of Changes

Updates the quickstart to put all of the queries in a single subscription.

## Testing

I ran the quickstart app locally.
