### PR TITLE
Make ws connection fail when token is not verified

### DIFF
--- a/packages/sdk/src/db_connection_impl.ts
+++ b/packages/sdk/src/db_connection_impl.ts
@@ -177,7 +177,9 @@ export class DbConnectionImpl<
   // We use them in testing.
   private clientCache: ClientCache;
   private ws?: WebsocketDecompressAdapter | WebsocketTestAdapter;
-  private wsPromise: Promise<WebsocketDecompressAdapter | WebsocketTestAdapter>;
+  private wsPromise: Promise<
+    WebsocketDecompressAdapter | WebsocketTestAdapter | undefined
+  >;
 
   constructor({
     uri,
@@ -233,16 +235,13 @@ export class DbConnectionImpl<
         };
         this.ws.onopen = this.#handleOnOpen.bind(this);
         this.ws.onmessage = this.#handleOnMessage.bind(this);
-
         return v;
       })
       .catch(e => {
         stdbLogger('error', 'Error connecting to SpacetimeDB WS');
-        this.#on('connectError', e);
-        // TODO(cloutiertyler): I don't know but this makes it compile and
-        // I don't have time to investigate how to do this properly.
-        // Otherwise `.catch` returns void.
-        throw e;
+        this.#emitter.emit('connectError', this, e);
+
+        return undefined;
       });
   }
 
@@ -501,10 +500,12 @@ export class DbConnectionImpl<
 
   #sendMessage(message: ws.ClientMessage): void {
     this.wsPromise.then(wsResolved => {
-      const writer = new BinaryWriter(1024);
-      ws.ClientMessage.serialize(writer, message);
-      const encoded = writer.getBuffer();
-      wsResolved.send(encoded);
+      if (wsResolved) {
+        const writer = new BinaryWriter(1024);
+        ws.ClientMessage.serialize(writer, message);
+        const encoded = writer.getBuffer();
+        wsResolved.send(encoded);
+      }
     });
   }
 
@@ -810,7 +811,9 @@ export class DbConnectionImpl<
    */
   disconnect(): void {
     this.wsPromise.then(wsResolved => {
-      wsResolved.close();
+      if (wsResolved) {
+        wsResolved.close();
+      }
     });
   }
 

--- a/packages/sdk/src/websocket_decompress_adapter.ts
+++ b/packages/sdk/src/websocket_decompress_adapter.ts
@@ -97,6 +97,10 @@ export class WebsocketDecompressAdapter {
       if (response.ok) {
         const { token } = await response.json();
         url.searchParams.set('token', token);
+      } else {
+        return Promise.reject(
+          new Error(`Failed to verify token: ${response.statusText}`)
+        );
       }
     }
     url.searchParams.set(


### PR DESCRIPTION
## The Problem
When using an invalid token there will be a 401 response code from `/v1/identity/websocket-token`. However as it stands there are no consequences to this and we are not able to react to that in any way.
Even worse: The `onConnect` callback will be called as if no problem has occured at all and is called with the invalid token. This leads to the SpacetimeDB server creating a new User/Identity constantly.

## Description of Changes
1. Reject the promise in createWebSocketFn of the `WebsocketDecompressAdapter`
2. Emit `connectError` in the catch block of the db connection.
3. Refactor `wsPromise` to accept `undefined` to avoid having an unhandled promise exception in the constructor (throw in catch).

As for 3. it is also possible to just not return anything and make it `Promise<void>`. That way in `#sendMessage` and `disconnect` functions would need to access `this.ws` directly instead of getting it from the Promise.

## API
- [ x ] This is an API breaking change to the SDK
It changes how errors are handled in the setup of the connection. I think it was more broken before though.

## Testing
1. Without this PR: Create a minimal example and invalidate the token in the local storage or in the cookie by removing a charcter for example
2. See that you get a 401 from `/v1/identity/websocket-token`
3. See that the onConnect callback still gets called
4. With this PR: Also create a minimal example and invalidte the token
5. See that the onConnectError callback is called and onConnect is not
