### PR TITLE
Fix so spacetimedb can be hosted with a pathname

### DIFF
--- a/examples/quickstart-chat/src/index.css
+++ b/examples/quickstart-chat/src/index.css
@@ -32,16 +32,16 @@ body,
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
+    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+  font-family:
+    source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }
 
 /* ----- Buttons ----- */

--- a/packages/sdk/src/db_connection_impl.ts
+++ b/packages/sdk/src/db_connection_impl.ts
@@ -194,8 +194,7 @@ export class DbConnectionImpl<
   }: DbConnectionConfig) {
     stdbLogger('info', 'Connecting to SpacetimeDB WS...');
 
-    let url = new URL(`v1/database/${nameOrAddress}/subscribe`, uri);
-
+    let url = new URL(uri);
     if (!/^wss?:/.test(uri.protocol)) {
       url.protocol = 'ws:';
     }
@@ -219,6 +218,7 @@ export class DbConnectionImpl<
 
     this.wsPromise = createWSFn({
       url,
+      nameOrAddress,
       wsProtocol: 'v1.bsatn.spacetimedb',
       authToken: token,
       compression: compression,

--- a/packages/sdk/src/websocket_decompress_adapter.ts
+++ b/packages/sdk/src/websocket_decompress_adapter.ts
@@ -63,6 +63,7 @@ export class WebsocketDecompressAdapter {
 
   static async createWebSocketFn({
     url,
+    nameOrAddress,
     wsProtocol,
     authToken,
     compression,
@@ -70,6 +71,7 @@ export class WebsocketDecompressAdapter {
   }: {
     url: URL;
     wsProtocol: string;
+    nameOrAddress: string;
     authToken?: string;
     compression: 'gzip' | 'none';
     lightMode: boolean;
@@ -90,7 +92,7 @@ export class WebsocketDecompressAdapter {
 
     if (authToken) {
       headers.set('Authorization', `Bearer ${authToken}`);
-      const tokenUrl = new URL('/v1/identity/websocket-token', url);
+      const tokenUrl = new URL('v1/identity/websocket-token', url);
       tokenUrl.protocol = url.protocol === 'wss:' ? 'https:' : 'http:';
 
       const response = await fetch(tokenUrl, { method: 'POST', headers });
@@ -103,15 +105,17 @@ export class WebsocketDecompressAdapter {
         );
       }
     }
-    url.searchParams.set(
+
+    const databaseUrl = new URL(`v1/database/${nameOrAddress}/subscribe`,url);
+    databaseUrl.searchParams.set(
       'compression',
       compression === 'gzip' ? 'Gzip' : 'None'
     );
     if (lightMode) {
-      url.searchParams.set('light', 'true');
+      databaseUrl.searchParams.set('light', 'true');
     }
 
-    const ws = new WS(url, wsProtocol);
+    const ws = new WS(databaseUrl, wsProtocol);
 
     return new WebsocketDecompressAdapter(ws);
   }

--- a/packages/sdk/src/websocket_decompress_adapter.ts
+++ b/packages/sdk/src/websocket_decompress_adapter.ts
@@ -106,7 +106,7 @@ export class WebsocketDecompressAdapter {
       }
     }
 
-    const databaseUrl = new URL(`v1/database/${nameOrAddress}/subscribe`,url);
+    const databaseUrl = new URL(`v1/database/${nameOrAddress}/subscribe`, url);
     databaseUrl.searchParams.set(
       'compression',
       compression === 'gzip' ? 'Gzip' : 'None'


### PR DESCRIPTION
## Description of Changes

Currently due to how URL's are handled in the sdk you cannot host a spacetimedb at a path on domain. Such as `wss://pixelz.games/api`. This is inconvenient since for web dev and spacetimedb you will have a minimum of 2 different servers running. One that handles at least static files and spacetimedb. The common web convention for stuff like this is just configure nginx to reroute traffic from a `/api' or '/service' path. This PR makes that possible to do.

## API

- [ ] This is an API breaking change to the SDK

This has no external effect and should cause no breaking changes.
## Requires SpacetimeDB PRs

There are no external PR's to this.

## Testing

Automated testing and built & compiled these changes into a change for my project.
- [ ] Describe a test for this PR that you have completed
A simple test is just have nginx handle spacetimedb at a pathname & not a pathname. If it works in both scenarios this code works as intended.

Basic example nginx config
```
server {
    listen 80;
    server_name {YOUR_HOST};
    server_tokens off;

    location /api/ {
        proxy_pass http://spacetimedb:3000/;
        proxy_http_version 1.1;
        proxy_set_header Host $host;
    }

    location / {
        root /usr/share/nginx;
        index index.html;
        access_log on;
    }
}
```