### PR TITLE
Require a minimum code gen version

### DIFF
--- a/packages/sdk/src/db_connection_builder.ts
+++ b/packages/sdk/src/db_connection_builder.ts
@@ -2,6 +2,7 @@ import { DbConnectionImpl, type ConnectionEvent } from './db_connection_impl';
 import { EventEmitter } from './event_emitter';
 import type { Identity } from './identity';
 import type RemoteModule from './spacetime_module';
+import { ensureMinimumVersionOrThrow } from './version';
 import { WebsocketDecompressAdapter } from './websocket_decompress_adapter';
 
 /**
@@ -214,6 +215,13 @@ export class DbConnectionBuilder<
         'Database name or address is required to connect to SpacetimeDB'
       );
     }
+    let versionString: string | undefined = undefined;
+    if (this.remoteModule.versionInfo) {
+      versionString = this.remoteModule.versionInfo.cliVersion;
+    }
+    // We could consider making this an `onConnectError` instead of throwing here.
+    // Ideally, it would be a compile time error, but I'm not sure how to accomplish that.
+    ensureMinimumVersionOrThrow(versionString);
 
     return this.dbConnectionConstructor(
       new DbConnectionImpl({

--- a/packages/sdk/src/db_connection_builder.ts
+++ b/packages/sdk/src/db_connection_builder.ts
@@ -215,13 +215,9 @@ export class DbConnectionBuilder<
         'Database name or address is required to connect to SpacetimeDB'
       );
     }
-    let versionString: string | undefined = undefined;
-    if (this.remoteModule.versionInfo) {
-      versionString = this.remoteModule.versionInfo.cliVersion;
-    }
     // We could consider making this an `onConnectError` instead of throwing here.
     // Ideally, it would be a compile time error, but I'm not sure how to accomplish that.
-    ensureMinimumVersionOrThrow(versionString);
+    ensureMinimumVersionOrThrow(this.remoteModule.versionInfo?.cliVersion);
 
     return this.dbConnectionConstructor(
       new DbConnectionImpl({

--- a/packages/sdk/src/spacetime_module.ts
+++ b/packages/sdk/src/spacetime_module.ts
@@ -22,4 +22,7 @@ export default interface RemoteModule {
     setReducerFlags: any
   ) => any;
   setReducerFlagsConstructor: () => any;
+  versionInfo?: {
+    cliVersion: string;
+  };
 }

--- a/packages/sdk/src/version.ts
+++ b/packages/sdk/src/version.ts
@@ -2,103 +2,134 @@ export type PrereleaseId = string | number;
 
 export type PreRelease = PrereleaseId[];
 
-
-function comparePreReleases(
-    a: PreRelease,
-    b: PreRelease
-): number {
-    const len = Math.min(a.length, b.length);
-    for (let i = 0; i < len; i++) {
-        const aPart = a[i];
-        const bPart = b[i];
-        if (aPart === bPart) continue;
-        if (typeof aPart === 'number' && typeof bPart === 'number') {
-            return aPart - bPart;
-        }
-        if (typeof aPart === 'string' && typeof bPart === 'string') {
-            return aPart.localeCompare(bPart);
-        }
-        // According to 11.4.3, numeric identifiers always have lower precedence than non-numeric identifiers.
-        // So if `a` is a string, it has higher precedence than `b`.
-        return typeof aPart === 'string' ? 1 : -1;
+// Compare pre-release identifiers according to the semver spec (https://semver.org/#spec-item-11).
+function comparePreReleases(a: PreRelease, b: PreRelease): number {
+  const len = Math.min(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    const aPart = a[i];
+    const bPart = b[i];
+    if (aPart === bPart) continue;
+    if (typeof aPart === 'number' && typeof bPart === 'number') {
+      return aPart - bPart;
     }
-    // See rule 11.4.4 in the semver spec.
-    return a.length - b.length;
+    if (typeof aPart === 'string' && typeof bPart === 'string') {
+      return aPart.localeCompare(bPart);
+    }
+    // According to item 11.4.3, numeric identifiers always have lower precedence than non-numeric identifiers.
+    // So if `a` is a string, it has higher precedence than `b`.
+    return typeof aPart === 'string' ? 1 : -1;
+  }
+  // See rule 11.4.4 in the semver spec.
+  return a.length - b.length;
 }
 
-// We don't use these, so I'm not going to parse it to spec.
+// We don't use these, and they don't matter for version ordering, so I'm not going to parse it to spec.
 export type BuildInfo = string;
 
+// This is exported for tests.
 export class SemanticVersion {
-    major: number;
-    minor: number;
-    patch: number;
-    preRelease: PreRelease | null;
-    buildInfo: BuildInfo | null;
-    
-    constructor(
-        major: number,
-        minor: number,
-        patch: number,
-        preRelease: PreRelease | null = null,
-        buildInfo: BuildInfo | null = null
-    ) {
-        this.major = major;
-        this.minor = minor;
-        this.patch = patch;
-        this.preRelease = preRelease;
-        this.buildInfo = buildInfo;
+  major: number;
+  minor: number;
+  patch: number;
+  preRelease: PreRelease | null;
+  buildInfo: BuildInfo | null;
+
+  constructor(
+    major: number,
+    minor: number,
+    patch: number,
+    preRelease: PreRelease | null = null,
+    buildInfo: BuildInfo | null = null
+  ) {
+    this.major = major;
+    this.minor = minor;
+    this.patch = patch;
+    this.preRelease = preRelease;
+    this.buildInfo = buildInfo;
+  }
+
+  toString(): string {
+    let versionString = `${this.major}.${this.minor}.${this.patch}`;
+    if (this.preRelease) {
+      versionString += `-${this.preRelease.join('.')}`;
     }
-    
-    toString(): string {
-        let versionString = `${this.major}.${this.minor}.${this.patch}`;
-        if (this.preRelease) {
-        versionString += `-${this.preRelease.join('.')}`;
-        }
-        if (this.buildInfo) {
-        versionString += `+${this.buildInfo}`;
-        }
-        return versionString;
+    if (this.buildInfo) {
+      versionString += `+${this.buildInfo}`;
+    }
+    return versionString;
+  }
+
+  compare(other: SemanticVersion): number {
+    if (this.major !== other.major) {
+      return this.major - other.major;
+    }
+    if (this.minor !== other.minor) {
+      return this.minor - other.minor;
+    }
+    if (this.patch !== other.patch) {
+      return this.patch - other.patch;
+    }
+    if (this.preRelease && other.preRelease) {
+      return comparePreReleases(this.preRelease, other.preRelease);
+    }
+    if (this.preRelease) {
+      return -1; // The version without a pre-release is greater.
+    }
+    if (other.preRelease) {
+      return -1; // Since we don't have a pre-release, this version is greater.
+    }
+    return 0; // versions are equal
+  }
+
+  clone(): SemanticVersion {
+    return new SemanticVersion(
+      this.major,
+      this.minor,
+      this.patch,
+      this.preRelease ? [...this.preRelease] : null,
+      this.buildInfo
+    );
+  }
+
+  static parseVersionString(version: string): SemanticVersion {
+    const regex =
+      /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([\da-zA-Z-]+(?:\.[\da-zA-Z-]+)*))?(?:\+([\da-zA-Z-]+(?:\.[\da-zA-Z-]+)*))?$/;
+    const match = version.match(regex);
+    if (!match) {
+      throw new Error(`Invalid version string: ${version}`);
     }
 
-    compare(other: SemanticVersion): number {
-        if (this.major !== other.major) {
-            return this.major - other.major;
-        }
-        if (this.minor !== other.minor) {
-            return this.minor - other.minor;
-        }
-        if (this.patch !== other.patch) {
-            return this.patch - other.patch;
-        }
-        if (this.preRelease && other.preRelease) {
-            return comparePreReleases(this.preRelease, other.preRelease);
-        }
-        if (this.preRelease) {
-            return -1; // The version without a pre-release is greater.
-        }
-        if (other.preRelease) {
-            return -1; // Since we don't have a pre-release, this version is greater.
-        }
-        return 0; // versions are equal
-    }
+    const major = parseInt(match[1], 10);
+    const minor = parseInt(match[2], 10);
+    const patch = parseInt(match[3], 10);
+    const preRelease = match[4]
+      ? match[4].split('.').map(id => (isNaN(Number(id)) ? id : Number(id)))
+      : null;
+    const buildInfo = match[5] || null;
 
-    static parseVersionString(version: string): SemanticVersion {
-        const regex = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([\da-zA-Z-]+(?:\.[\da-zA-Z-]+)*))?(?:\+([\da-zA-Z-]+(?:\.[\da-zA-Z-]+)*))?$/;
-        const match = version.match(regex);
-        if (!match) {
-            throw new Error(`Invalid version string: ${version}`);
-        }
-        
-        const major = parseInt(match[1], 10);
-        const minor = parseInt(match[2], 10);
-        const patch = parseInt(match[3], 10);
-        const preRelease = match[4] ? match[4].split('.').map(id => isNaN(Number(id)) ? id : Number(id)) : null;
-        const buildInfo = match[5] || null;
-        
-        return new SemanticVersion(major, minor, patch, preRelease, buildInfo);
-    }
+    return new SemanticVersion(major, minor, patch, preRelease, buildInfo);
+  }
 }
 
 // The SDK depends on some module information that was not generated before this version.
-export const MINIMUM_CLI_VERSION: SemanticVersion = new SemanticVersion(1, 1, 2);
+export const _MINIMUM_CLI_VERSION: SemanticVersion = new SemanticVersion(
+  1,
+  1,
+  2
+);
+
+export function ensureMinimumVersionOrThrow(versionString?: string): void {
+  if (versionString === undefined) {
+    throw new Error(versionErrorMessage(versionString));
+  }
+  const version = SemanticVersion.parseVersionString(versionString);
+  if (version.compare(_MINIMUM_CLI_VERSION) < 0) {
+    throw new Error(versionErrorMessage(versionString));
+  }
+}
+
+function versionErrorMessage(incompatibleVersion?: string): string {
+  const badVersion =
+    incompatibleVersion === undefined ? 'unknown' : incompatibleVersion;
+  return `Module code was generated with an incompatible version of the spacetimedb cli (${incompatibleVersion}).  Update the cli version to at least ${_MINIMUM_CLI_VERSION.toString()} and regenerate the bindings. You can upgrade to the latest cli version by running: spacetime version upgrade`;
+}

--- a/packages/sdk/src/version.ts
+++ b/packages/sdk/src/version.ts
@@ -1,0 +1,104 @@
+export type PrereleaseId = string | number;
+
+export type PreRelease = PrereleaseId[];
+
+
+function comparePreReleases(
+    a: PreRelease,
+    b: PreRelease
+): number {
+    const len = Math.min(a.length, b.length);
+    for (let i = 0; i < len; i++) {
+        const aPart = a[i];
+        const bPart = b[i];
+        if (aPart === bPart) continue;
+        if (typeof aPart === 'number' && typeof bPart === 'number') {
+            return aPart - bPart;
+        }
+        if (typeof aPart === 'string' && typeof bPart === 'string') {
+            return aPart.localeCompare(bPart);
+        }
+        // According to 11.4.3, numeric identifiers always have lower precedence than non-numeric identifiers.
+        // So if `a` is a string, it has higher precedence than `b`.
+        return typeof aPart === 'string' ? 1 : -1;
+    }
+    // See rule 11.4.4 in the semver spec.
+    return a.length - b.length;
+}
+
+// We don't use these, so I'm not going to parse it to spec.
+export type BuildInfo = string;
+
+export class SemanticVersion {
+    major: number;
+    minor: number;
+    patch: number;
+    preRelease: PreRelease | null;
+    buildInfo: BuildInfo | null;
+    
+    constructor(
+        major: number,
+        minor: number,
+        patch: number,
+        preRelease: PreRelease | null = null,
+        buildInfo: BuildInfo | null = null
+    ) {
+        this.major = major;
+        this.minor = minor;
+        this.patch = patch;
+        this.preRelease = preRelease;
+        this.buildInfo = buildInfo;
+    }
+    
+    toString(): string {
+        let versionString = `${this.major}.${this.minor}.${this.patch}`;
+        if (this.preRelease) {
+        versionString += `-${this.preRelease.join('.')}`;
+        }
+        if (this.buildInfo) {
+        versionString += `+${this.buildInfo}`;
+        }
+        return versionString;
+    }
+
+    compare(other: SemanticVersion): number {
+        if (this.major !== other.major) {
+            return this.major - other.major;
+        }
+        if (this.minor !== other.minor) {
+            return this.minor - other.minor;
+        }
+        if (this.patch !== other.patch) {
+            return this.patch - other.patch;
+        }
+        if (this.preRelease && other.preRelease) {
+            return comparePreReleases(this.preRelease, other.preRelease);
+        }
+        if (this.preRelease) {
+            return -1; // The version without a pre-release is greater.
+        }
+        if (other.preRelease) {
+            return -1; // Since we don't have a pre-release, this version is greater.
+        }
+        return 0; // versions are equal
+    }
+
+    static parseVersionString(version: string): SemanticVersion {
+        const regex = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([\da-zA-Z-]+(?:\.[\da-zA-Z-]+)*))?(?:\+([\da-zA-Z-]+(?:\.[\da-zA-Z-]+)*))?$/;
+        const match = version.match(regex);
+        if (!match) {
+            throw new Error(`Invalid version string: ${version}`);
+        }
+        
+        const major = parseInt(match[1], 10);
+        const minor = parseInt(match[2], 10);
+        const patch = parseInt(match[3], 10);
+        const preRelease = match[4] ? match[4].split('.').map(id => isNaN(Number(id)) ? id : Number(id)) : null;
+        const buildInfo = match[5] || null;
+        
+        return new SemanticVersion(major, minor, patch, preRelease, buildInfo);
+    }
+}
+
+// The SDK depends on some module information that was not generated before this version.
+export const MINIMUM_CLI_VERSION: SemanticVersion = new SemanticVersion(1, 1, 2);

--- a/packages/sdk/tests/version.test.ts
+++ b/packages/sdk/tests/version.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "vitest"
+import {SemanticVersion} from '../src/version.ts';
+
+describe('SemanticVersion', () => {
+    describe('Parsing semantic version strings', () => {
+        test('valid versions', () => {
+            // This is a dummy test to ensure that the test suite runs
+            // and that the TableCache is working as expected.
+            // You can add more tests here to cover different scenarios.
+            //parseVersionString('1.0.0');
+            let tests: [string, SemanticVersion][] = [
+                ['1.0.0', new SemanticVersion(1, 0, 0)],
+                ['1.0.0-alpha', new SemanticVersion(1, 0, 0, ['alpha'])],
+                ['1.0.0-alpha.1', new SemanticVersion(1, 0, 0, ['alpha', 1])],
+                ['1.0.0-alpha.20.beta', new SemanticVersion(1, 0, 0, ['alpha', 20, 'beta'])],
+                ['1.0.0-alpha.beta', new SemanticVersion(1, 0, 0, ['alpha', 'beta'])],
+                ['0.2.1', new SemanticVersion(0, 2, 1)],
+                ['10.2.1', new SemanticVersion(10, 2, 1)],
+                ['1.0.0+20130313144700', new SemanticVersion(1, 0, 0, null, '20130313144700')],
+                ['1.0.0-alpha+001', new SemanticVersion(1, 0, 0, ['alpha'], '001')],
+                ['1.0.0-alpha.beta+exp.sha.5114f85', new SemanticVersion(1, 0, 0, ['alpha', 'beta'], 'exp.sha.5114f85')],
+                ['1.0.0+exp.sha.5114f85', new SemanticVersion(1, 0, 0, null, 'exp.sha.5114f85')],
+            ];
+            for (const [versionString, expectedVersion] of tests) {
+                const parsedVersion = SemanticVersion.parseVersionString(versionString);
+                expect(parsedVersion, `Parsing ${versionString}`).toEqual(expectedVersion);
+            }
+        });
+
+        test('invalid version strings should throw an error', () => {
+            let invalidTests: string[] = [
+                '1.0', // Missing patch version
+                '1', // Missing minor and patch versions
+                '1.0.0-', // Trailing hyphen
+                '1.0.0+', // Trailing plus
+                '1.0.0-alpha..1', // Double dots in pre-release
+                '1.0.0+build..info', // Double dots in build metadata
+                '1.0.0-alpha!', // Invalid character in pre-release
+                '1.0.0+build!', // Invalid character in build metadata
+                'abc.def.ghi', // Completely invalid format
+                '', // Empty string
+            ];
+            for (const versionString of invalidTests) {
+                expect(() => SemanticVersion.parseVersionString(versionString))
+                    .toThrow(`Invalid version string: ${versionString}`);
+            }
+        });
+    });
+    describe('Comparing SemanticVersions', () => {
+        function normalizedCompare(
+            version1: SemanticVersion,
+            version2: SemanticVersion
+        ): number {
+            let c = version1.compare(version2);
+            if (c < 0) {
+                return -1;
+            }
+            if (c > 0) {
+                return 1;
+            }
+            return 0;
+        }
+        test('test comparison order', () => {
+            let cases: [string, string, number][] = [
+                ['1.0.0', '1.0.0', 0],
+                ['1.0.0', '1.0.1', -1],
+                ['1.10.0', '1.2.1', 1],
+                ['1.2.1', '1.10.0', -1],
+                ['1.0.1', '1.0.0', 1],
+                ['1.0.0-alpha', '1.0.0-alpha', 0],
+                ['1.0.0-alpha', '1.0.0-beta', -1],
+                ['1.0.0-beta', '1.0.0-alpha', 1],
+                ['1.0.0-alpha', '1.0.0-alpha.beta', -1],
+                ['1.0.0-1', '1.0.0-alpha.beta', -1], 
+                ['1.0.0-alpha.1', '1.0.0-alpha.2', -1], 
+                ['1.0.0-alpha.beta', '1.0.0-alpha', 1],
+                ['2.0.0-alpha.beta', '2.0.0-alpha.beta', 0],
+                ['2.0.0-alpha.beta+001', '2.0.0-alpha.beta+001', 0],
+                ['2.0.0-alpha.beta+001', '2.0.0-alpha.beta+002', 0], // Build tags don't affect comparison
+
+            ];
+            for (const [left, right, expectedComparison] of cases) {
+                const parsedLeft = SemanticVersion.parseVersionString(left);
+                const parsedRight = SemanticVersion.parseVersionString(right);
+                expect(normalizedCompare(parsedLeft, parsedRight), "Comparing " + left + " and " + right).toEqual(expectedComparison);
+            }
+        });
+    });
+});

--- a/packages/sdk/tests/version.test.ts
+++ b/packages/sdk/tests/version.test.ts
@@ -1,89 +1,185 @@
-import { describe, expect, test } from "vitest"
-import {SemanticVersion} from '../src/version.ts';
+import { describe, expect, test } from 'vitest';
+import {
+  SemanticVersion,
+  _MINIMUM_CLI_VERSION,
+  ensureMinimumVersionOrThrow,
+} from '../src/version.ts';
 
 describe('SemanticVersion', () => {
-    describe('Parsing semantic version strings', () => {
-        test('valid versions', () => {
-            // This is a dummy test to ensure that the test suite runs
-            // and that the TableCache is working as expected.
-            // You can add more tests here to cover different scenarios.
-            //parseVersionString('1.0.0');
-            let tests: [string, SemanticVersion][] = [
-                ['1.0.0', new SemanticVersion(1, 0, 0)],
-                ['1.0.0-alpha', new SemanticVersion(1, 0, 0, ['alpha'])],
-                ['1.0.0-alpha.1', new SemanticVersion(1, 0, 0, ['alpha', 1])],
-                ['1.0.0-alpha.20.beta', new SemanticVersion(1, 0, 0, ['alpha', 20, 'beta'])],
-                ['1.0.0-alpha.beta', new SemanticVersion(1, 0, 0, ['alpha', 'beta'])],
-                ['0.2.1', new SemanticVersion(0, 2, 1)],
-                ['10.2.1', new SemanticVersion(10, 2, 1)],
-                ['1.0.0+20130313144700', new SemanticVersion(1, 0, 0, null, '20130313144700')],
-                ['1.0.0-alpha+001', new SemanticVersion(1, 0, 0, ['alpha'], '001')],
-                ['1.0.0-alpha.beta+exp.sha.5114f85', new SemanticVersion(1, 0, 0, ['alpha', 'beta'], 'exp.sha.5114f85')],
-                ['1.0.0+exp.sha.5114f85', new SemanticVersion(1, 0, 0, null, 'exp.sha.5114f85')],
-            ];
-            for (const [versionString, expectedVersion] of tests) {
-                const parsedVersion = SemanticVersion.parseVersionString(versionString);
-                expect(parsedVersion, `Parsing ${versionString}`).toEqual(expectedVersion);
-            }
-        });
-
-        test('invalid version strings should throw an error', () => {
-            let invalidTests: string[] = [
-                '1.0', // Missing patch version
-                '1', // Missing minor and patch versions
-                '1.0.0-', // Trailing hyphen
-                '1.0.0+', // Trailing plus
-                '1.0.0-alpha..1', // Double dots in pre-release
-                '1.0.0+build..info', // Double dots in build metadata
-                '1.0.0-alpha!', // Invalid character in pre-release
-                '1.0.0+build!', // Invalid character in build metadata
-                'abc.def.ghi', // Completely invalid format
-                '', // Empty string
-            ];
-            for (const versionString of invalidTests) {
-                expect(() => SemanticVersion.parseVersionString(versionString))
-                    .toThrow(`Invalid version string: ${versionString}`);
-            }
-        });
-    });
-    describe('Comparing SemanticVersions', () => {
-        function normalizedCompare(
-            version1: SemanticVersion,
-            version2: SemanticVersion
-        ): number {
-            let c = version1.compare(version2);
-            if (c < 0) {
-                return -1;
-            }
-            if (c > 0) {
-                return 1;
-            }
-            return 0;
+  describe('Minimum version check', () => {
+    test('older versions throw an error', () => {
+      let olderVersions: string[] = ['0.0.1', '0.1.0', '1.1.0'];
+      if (_MINIMUM_CLI_VERSION.major > 0) {
+        let olderVersion = _MINIMUM_CLI_VERSION.clone();
+        olderVersion.major -= 1;
+        olderVersions.push(olderVersion.toString());
+      }
+      if (_MINIMUM_CLI_VERSION.minor > 0) {
+        let olderVersion = _MINIMUM_CLI_VERSION.clone();
+        olderVersion.minor -= 1;
+        olderVersions.push(olderVersion.toString());
+      }
+      if (_MINIMUM_CLI_VERSION.patch > 0) {
+        let olderVersion = _MINIMUM_CLI_VERSION.clone();
+        olderVersion.patch -= 1;
+        olderVersions.push(olderVersion.toString());
+      }
+      if (!_MINIMUM_CLI_VERSION.preRelease) {
+        let olderVersion = _MINIMUM_CLI_VERSION.clone();
+        olderVersion.preRelease = ['alpha'];
+        olderVersions.push(olderVersion.toString());
+      }
+      let olderVersion = _MINIMUM_CLI_VERSION.clone();
+      if (olderVersion.preRelease != null) {
+        if (typeof olderVersion.preRelease[0] === 'number') {
+          olderVersion.preRelease[0] = olderVersion.preRelease[0] - 1;
+        } else {
+          olderVersion.preRelease[0] += 'alpha';
         }
-        test('test comparison order', () => {
-            let cases: [string, string, number][] = [
-                ['1.0.0', '1.0.0', 0],
-                ['1.0.0', '1.0.1', -1],
-                ['1.10.0', '1.2.1', 1],
-                ['1.2.1', '1.10.0', -1],
-                ['1.0.1', '1.0.0', 1],
-                ['1.0.0-alpha', '1.0.0-alpha', 0],
-                ['1.0.0-alpha', '1.0.0-beta', -1],
-                ['1.0.0-beta', '1.0.0-alpha', 1],
-                ['1.0.0-alpha', '1.0.0-alpha.beta', -1],
-                ['1.0.0-1', '1.0.0-alpha.beta', -1], 
-                ['1.0.0-alpha.1', '1.0.0-alpha.2', -1], 
-                ['1.0.0-alpha.beta', '1.0.0-alpha', 1],
-                ['2.0.0-alpha.beta', '2.0.0-alpha.beta', 0],
-                ['2.0.0-alpha.beta+001', '2.0.0-alpha.beta+001', 0],
-                ['2.0.0-alpha.beta+001', '2.0.0-alpha.beta+002', 0], // Build tags don't affect comparison
-
-            ];
-            for (const [left, right, expectedComparison] of cases) {
-                const parsedLeft = SemanticVersion.parseVersionString(left);
-                const parsedRight = SemanticVersion.parseVersionString(right);
-                expect(normalizedCompare(parsedLeft, parsedRight), "Comparing " + left + " and " + right).toEqual(expectedComparison);
-            }
-        });
+      }
+      const errorRegexp = new RegExp(
+        '.*generated with an incompatible version.*'
+      );
+      for (const versionString of olderVersions) {
+        expect(
+          () => ensureMinimumVersionOrThrow(versionString),
+          `Checking ${versionString}`
+        ).toThrow(errorRegexp);
+      }
     });
+
+    test('newer versions do not throw', () => {
+      let newerVersions: string[] = [_MINIMUM_CLI_VERSION.toString()];
+      let newVersion = _MINIMUM_CLI_VERSION.clone();
+      newVersion.major += 1;
+      newerVersions.push(newVersion.toString());
+      newVersion = _MINIMUM_CLI_VERSION.clone();
+      newVersion.minor += 1;
+      newerVersions.push(newVersion.toString());
+      newVersion = _MINIMUM_CLI_VERSION.clone();
+      newVersion.patch += 1;
+      newerVersions.push(newVersion.toString());
+      newVersion = _MINIMUM_CLI_VERSION.clone();
+      if (newVersion.preRelease != null) {
+        newVersion.preRelease = null;
+        newerVersions.push(newVersion.toString());
+      }
+      const errorRegexp = new RegExp(
+        '.*generated with an incompatible version.*'
+      );
+      for (const versionString of newerVersions) {
+        expect(
+          () => ensureMinimumVersionOrThrow(versionString),
+          `Checking ${versionString}`
+        ).not.toThrow();
+      }
+    });
+  });
+  describe('Parsing semantic version strings', () => {
+    test('valid versions', () => {
+      // This is a dummy test to ensure that the test suite runs
+      // and that the TableCache is working as expected.
+      // You can add more tests here to cover different scenarios.
+      //parseVersionString('1.0.0');
+      let tests: [string, SemanticVersion][] = [
+        ['1.0.0', new SemanticVersion(1, 0, 0)],
+        ['1.0.0-alpha', new SemanticVersion(1, 0, 0, ['alpha'])],
+        ['1.0.0-alpha.1', new SemanticVersion(1, 0, 0, ['alpha', 1])],
+        [
+          '1.0.0-alpha.20.beta',
+          new SemanticVersion(1, 0, 0, ['alpha', 20, 'beta']),
+        ],
+        ['1.0.0-alpha.beta', new SemanticVersion(1, 0, 0, ['alpha', 'beta'])],
+        ['0.2.1', new SemanticVersion(0, 2, 1)],
+        ['0.0.0', new SemanticVersion(0, 0, 0)],
+        ['10.2.1', new SemanticVersion(10, 2, 1)],
+        [
+          '1.0.0+20130313144700',
+          new SemanticVersion(1, 0, 0, null, '20130313144700'),
+        ],
+        ['1.0.0-alpha+001', new SemanticVersion(1, 0, 0, ['alpha'], '001')],
+        [
+          '1.0.0-alpha.beta+exp.sha.5114f85',
+          new SemanticVersion(1, 0, 0, ['alpha', 'beta'], 'exp.sha.5114f85'),
+        ],
+        [
+          '1.0.0+exp.sha.5114f85',
+          new SemanticVersion(1, 0, 0, null, 'exp.sha.5114f85'),
+        ],
+      ];
+      for (const [versionString, expectedVersion] of tests) {
+        const parsedVersion = SemanticVersion.parseVersionString(versionString);
+        expect(parsedVersion, `Parsing ${versionString}`).toEqual(
+          expectedVersion
+        );
+      }
+    });
+
+    test('invalid version strings should throw an error', () => {
+      let invalidTests: string[] = [
+        '1.0', // Missing patch version
+        '1', // Missing minor and patch versions
+        '1.0.0-', // Trailing hyphen
+        '1.0.0+', // Trailing plus
+        '1.0.0-alpha..1', // Double dots in pre-release
+        '1.0.0+build..info', // Double dots in build metadata
+        '1.0.0-alpha!', // Invalid character in pre-release
+        '1.0.0+build!', // Invalid character in build metadata
+        'abc.def.ghi', // Completely invalid format
+        '', // Empty string
+      ];
+      for (const versionString of invalidTests) {
+        expect(() => SemanticVersion.parseVersionString(versionString)).toThrow(
+          `Invalid version string: ${versionString}`
+        );
+
+        // Checking the minimum version should also fail.
+        expect(() => ensureMinimumVersionOrThrow(versionString)).toThrow(
+          `Invalid version string: ${versionString}`
+        );
+      }
+    });
+  });
+  describe('Comparing SemanticVersions', () => {
+    function normalizedCompare(
+      version1: SemanticVersion,
+      version2: SemanticVersion
+    ): number {
+      let c = version1.compare(version2);
+      if (c < 0) {
+        return -1;
+      }
+      if (c > 0) {
+        return 1;
+      }
+      return 0;
+    }
+    test('test comparison order', () => {
+      let cases: [string, string, number][] = [
+        ['1.0.0', '1.0.0', 0],
+        ['1.0.0', '1.0.1', -1],
+        ['1.10.0', '1.2.1', 1],
+        ['1.2.1', '1.10.0', -1],
+        ['1.0.1', '1.0.0', 1],
+        ['1.0.0-alpha', '1.0.0-alpha', 0],
+        ['1.0.0-alpha', '1.0.0-beta', -1],
+        ['1.0.0-beta', '1.0.0-alpha', 1],
+        ['1.0.0-alpha', '1.0.0-alpha.beta', -1],
+        ['1.0.0-1', '1.0.0-alpha.beta', -1],
+        ['1.0.0-alpha.1', '1.0.0-alpha.2', -1],
+        ['1.0.0-alpha.beta', '1.0.0-alpha', 1],
+        ['2.0.0-alpha.beta', '2.0.0-alpha.beta', 0],
+        ['2.0.0-alpha.beta+001', '2.0.0-alpha.beta+001', 0],
+        ['2.0.0-alpha.beta+001', '2.0.0-alpha.beta+002', 0], // Build tags don't affect comparison
+      ];
+      for (const [left, right, expectedComparison] of cases) {
+        const parsedLeft = SemanticVersion.parseVersionString(left);
+        const parsedRight = SemanticVersion.parseVersionString(right);
+        expect(
+          normalizedCompare(parsedLeft, parsedRight),
+          'Comparing ' + left + ' and ' + right
+        ).toEqual(expectedComparison);
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Description of Changes

This will throw an error if the remote module was generated with a CLI version that is too old for the typescript sdk.

## API

This will now throw an error when building a db connection, rather than having arbitrary errors happen for incompatible versions.

## Requires SpacetimeDB PRs

This will make master broken until https://github.com/clockworklabs/SpacetimeDB/pull/2671 is released (which is the point of this PR).

## Testing

There is unit testing for the sem ver logic, and anything using generated code will have some degree of coverage.
