### PR TITLE
Release 1.2.0

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clockworklabs/spacetimedb-sdk",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "SDK for SpacetimeDB",
   "author": {
     "name": "Clockwork Labs",


### PR DESCRIPTION
## Description of Changes

Bump version to 1.2.0.

Merging this PR will **release** this package version.

## API

No breaking changes.

## Requires SpacetimeDB PRs

I don't think this version bump itself requires anything.

## Testing

CI only