### PR TITLE
Fixed token transfer for `subscrbe` url

### DIFF
--- a/packages/sdk/src/websocket_decompress_adapter.ts
+++ b/packages/sdk/src/websocket_decompress_adapter.ts
@@ -107,6 +107,11 @@ export class WebsocketDecompressAdapter {
     }
 
     const databaseUrl = new URL(`v1/database/${nameOrAddress}/subscribe`, url);
+
+    if (url.searchParams.has("token")) {
+      databaseUrl.searchParams.set("token", url.searchParams.get("token"));
+    }
+
     databaseUrl.searchParams.set(
       'compression',
       compression === 'gzip' ? 'Gzip' : 'None'


### PR DESCRIPTION
## Description of Changes

In the current implementation, if the token was received via `v1/identity/websocket-token`, it was not passed for `databaseUrl` because creating the address via `new URL()` ignores the query string. I've added a check to see if the token is available and set it if it is, which fixes the connection error.

## API

This fix shouldn't break the API

## Testing

Before the fix:
![image](https://github.com/user-attachments/assets/eea99172-9407-447c-a704-967e294c14f8)

Before the fix:

Example of how this fix works:
1- current token setting
2 - the fix that transfers the token

The console shows the result of logging the databaseUrl variable
![image](https://github.com/user-attachments/assets/2bde9ba9-6fe1-41bb-a867-c1b9430eb57a)
