### PR TITLE
Update db_connection_impl.ts

### DIFF
--- a/packages/sdk/src/db_connection_impl.ts
+++ b/packages/sdk/src/db_connection_impl.ts
@@ -196,7 +196,7 @@ export class DbConnectionImpl<
 
     let url = new URL(uri);
     if (!/^wss?:/.test(uri.protocol)) {
-      url.protocol = 'ws:';
+      url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
     }
 
     this.identity = identity;


### PR DESCRIPTION
fix for https://github.com/clockworklabs/SpacetimeDB/issues/2896

## Description of Changes

Fixes an instance where a url protocol was improperly being swapped. Existing behavior led to `https:` & `http:` being swapped to `ws:`, whereas `https:` should swap to `wss:`.