### PR TITLE
Bump version to 1.2.1 for release

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clockworklabs/spacetimedb-sdk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "SDK for SpacetimeDB",
   "author": {
     "name": "Clockwork Labs",


### PR DESCRIPTION
## Description of Changes

We have merged two bugfixes (#194 and #195), and we'd like to release these.

## API

- [ ] This is an API breaking change to the SDK

No breaking changes

## Requires SpacetimeDB PRs

None

## Testing

See those PRs. This is just a version bump.