### PR TITLE
Use toString() instead of an instance of Url when opening the websocket

### DIFF
--- a/packages/sdk/src/websocket_decompress_adapter.ts
+++ b/packages/sdk/src/websocket_decompress_adapter.ts
@@ -121,7 +121,7 @@ export class WebsocketDecompressAdapter {
       databaseUrl.searchParams.set('light', 'true');
     }
 
-    const ws = new WS(databaseUrl, wsProtocol);
+    const ws = new WS(databaseUrl.toString(), wsProtocol);
 
     return new WebsocketDecompressAdapter(ws);
   }


### PR DESCRIPTION
## Description of Changes

Connection to an instance fails with React Native, this is the error:
[Error: Exception in HostFunction: Expected argument 0 of method "connect" to be a string, but got an object]
This error was caused by React Native implementation of Websocket, in our SDK we use an instance of Url to pass all the parameters like token, compression, etc. but React Native requires this parameter to be a string and not Url | **string.**

## Testing


- [x] Setup a React Native app if you're brave enough and try to connect to a SpacetimeDB instance
