### PR TITLE
Release 1.2.2

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clockworklabs/spacetimedb-sdk",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "SDK for SpacetimeDB",
   "author": {
     "name": "Clockwork Labs",


### PR DESCRIPTION
## Description of Changes

Bump version numbers to 1.2.2. Merging this PR will release this version (because we don't have any outstanding changesets).

Includes these commits:
```
e2f0427 Use toString() instead of an instance of Url when opening the websocket connection
d808e41 Improve performance of row ids (#180)
fdd4618 CI - Test that quickstart-chat builds (#197)
6ea0c6f Require a minimum code gen version (#186)
```

## API

- [ ] This is an API breaking change to the SDK

No breaking changes

## Requires SpacetimeDB PRs

None

## Testing

None