### PR TITLE
fix Github link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 `@clockworklabs/spacetimedb-sdk` is a TypeScript SDK for SpacetimeDB.
 
-Source code can be found here on [GitHub](https://github.com/clockworklabs/SpacetimeDB/blob/master/sdks/typescript/packages/sdk).
+Source code can be found here on [GitHub](https://github.com/clockworklabs/spacetimedb-typescript-sdk).


### PR DESCRIPTION
the github link used is broken. the SDK is in this repo, not the main one anymore.